### PR TITLE
Publish Docker image to Docker Hub on production deploy

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -9,6 +9,8 @@ env:
   AWS_REGION: us-west-1
   ECR_REPO_NAME: image-api-prod
   STACK_NAME: image-api-prod
+  DOCKERHUB_USERNAME: nicobistolfi
+  DOCKERHUB_REPO_NAME: eagle-image-api
 
 jobs:
   ci:
@@ -51,18 +53,19 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: nicobistolfi
+          username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKER_PAT }}
 
       - name: Push Docker image to Docker Hub
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
+          DOCKERHUB_IMAGE: ${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_REPO_NAME }}
         run: |
-          docker tag $ECR_REGISTRY/$ECR_REPO_NAME:$IMAGE_TAG nicobistolfi/eagle-image-api:$IMAGE_TAG
-          docker tag $ECR_REGISTRY/$ECR_REPO_NAME:$IMAGE_TAG nicobistolfi/eagle-image-api:latest
-          docker push nicobistolfi/eagle-image-api:$IMAGE_TAG
-          docker push nicobistolfi/eagle-image-api:latest
+          docker tag $ECR_REGISTRY/$ECR_REPO_NAME:$IMAGE_TAG $DOCKERHUB_IMAGE:$IMAGE_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPO_NAME:$IMAGE_TAG $DOCKERHUB_IMAGE:latest
+          docker push $DOCKERHUB_IMAGE:$IMAGE_TAG
+          docker push $DOCKERHUB_IMAGE:latest
 
       - name: Deploy CloudFormation stack
         env:

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -48,6 +48,22 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPO_NAME:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPO_NAME:latest
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: nicobistolfi
+          password: ${{ secrets.DOCKER_PAT }}
+
+      - name: Push Docker image to Docker Hub
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker tag $ECR_REGISTRY/$ECR_REPO_NAME:$IMAGE_TAG nicobistolfi/eagle-image-api:$IMAGE_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPO_NAME:$IMAGE_TAG nicobistolfi/eagle-image-api:latest
+          docker push nicobistolfi/eagle-image-api:$IMAGE_TAG
+          docker push nicobistolfi/eagle-image-api:latest
+
       - name: Deploy CloudFormation stack
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}


### PR DESCRIPTION
## Summary
- move the Docker Hub image coordinates in the production deploy workflow into workflow-level variables
- keep the existing ECR build/push and CloudFormation deploy flow unchanged
- continue publishing the production image to Docker Hub with the prod `DOCKER_PAT` secret

## Validation
- `git diff --check`
- `npx -y yaml valid < .github/workflows/deploy-main.yml`

Closes #34