### PR TITLE
Meet awesome-go listing requirements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Something is not working as documented
+title: ''
+labels: bug
+assignees: ''
+---
+
+## What happened
+
+<!-- What did you observe? Include the request URL with its query parameters,
+     with any private hostname redacted. -->
+
+## What you expected
+
+## How to reproduce
+
+1.
+2.
+
+## Environment
+
+- Eagle version or commit:
+- Deployment: AWS Lambda / Docker / local
+- libvips version (`vips --version`):
+- Source image format and size:
+
+## Logs
+
+<!-- Relevant CloudWatch or container output. Redact credentials. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest a capability Eagle does not have yet
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## The problem
+
+<!-- What are you trying to do that Eagle makes hard or impossible? -->
+
+## What you would like
+
+<!-- If it is a new query parameter or CLI flag, show the call you want to make. -->
+
+## Alternatives you considered
+
+## Anything else
+
+<!-- Links to how other image services handle this, if relevant. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## What this changes
+
+<!-- What does this do, and why is it needed? Link the issue it closes. -->
+
+## How it was tested
+
+<!-- Which tests cover it? Anything you verified by hand? -->
+
+## Checklist
+
+- [ ] `go test -race ./...` passes
+- [ ] `gofmt -l .` prints nothing
+- [ ] `go vet ./...`, `staticcheck ./...`, and `golangci-lint run ./...` pass
+- [ ] New behaviour has tests; bug fixes have a test that fails without the fix
+- [ ] Exported identifiers have doc comments
+- [ ] README updated if a parameter, environment variable, or CLI flag changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,21 @@
 name: Go CI
 
 on:
+  # Run on its own for pull requests and main so the status badge and the
+  # coverage upload reflect reality, including for pull requests from forks.
+  push:
+    branches:
+      - main
+  pull_request:
+  # Still callable, so the deploy workflows gate on a green build.
   workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ci:
@@ -33,7 +47,14 @@ jobs:
         run: go build ./...
 
       - name: Test
-        run: go test -race -coverprofile=coverage.out ./...
+        run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       - name: Vet
         run: go vet ./...
@@ -54,6 +75,6 @@ jobs:
           install-go: false
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: latest
+          version: v2.10.1

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -22,6 +22,8 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     environment: prod
+    outputs:
+      api_url: ${{ steps.stack-outputs.outputs.api_url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -101,14 +103,26 @@ jobs:
             --rest-api-id $REST_API_ID \
             --stage-name prod
 
-  newman:
+      - name: Read stack outputs
+        id: stack-outputs
+        run: |
+          API_URL=$(aws cloudformation describe-stacks \
+            --stack-name $STACK_NAME \
+            --query "Stacks[0].Outputs[?OutputKey=='ApiUrl'].OutputValue" \
+            --output text)
+          echo "api_url=$API_URL" >> "$GITHUB_OUTPUT"
+          echo "Deployed to $API_URL"
+
+  smoke:
+    name: smoke test
     runs-on: ubuntu-latest
     needs: deploy
     environment: prod
     steps:
       - uses: actions/checkout@v4
-      - uses: matt-ball/newman-action@master
-        with:
-          apiKey: ${{ secrets.POSTMAN_API_KEY }}
-          collection: ${{ secrets.POSTMAN_COLLECTION_ID }}
-          environment: ${{ secrets.POSTMAN_ENV }}
+
+      - name: Smoke test the deployment
+        run: |
+          scripts/smoke-test.sh \
+            "${{ needs.deploy.outputs.api_url }}" \
+            "${{ vars.API_ENDPOINT || '/api/v1/image' }}"

--- a/.github/workflows/deploy-pull.yml
+++ b/.github/workflows/deploy-pull.yml
@@ -20,6 +20,8 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     environment: dev
+    outputs:
+      api_url: ${{ steps.stack-outputs.outputs.api_url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -82,14 +84,26 @@ jobs:
             --rest-api-id $REST_API_ID \
             --stage-name dev
 
-  newman:
+      - name: Read stack outputs
+        id: stack-outputs
+        run: |
+          API_URL=$(aws cloudformation describe-stacks \
+            --stack-name $STACK_NAME \
+            --query "Stacks[0].Outputs[?OutputKey=='ApiUrl'].OutputValue" \
+            --output text)
+          echo "api_url=$API_URL" >> "$GITHUB_OUTPUT"
+          echo "Deployed to $API_URL"
+
+  smoke:
+    name: smoke test
     runs-on: ubuntu-latest
     needs: deploy
     environment: dev
     steps:
       - uses: actions/checkout@v4
-      - uses: matt-ball/newman-action@master
-        with:
-          apiKey: ${{ secrets.POSTMAN_API_KEY }}
-          collection: ${{ secrets.POSTMAN_COLLECTION_ID }}
-          environment: ${{ secrets.POSTMAN_ENV }}
+
+      - name: Smoke test the deployment
+        run: |
+          scripts/smoke-test.sh \
+            "${{ needs.deploy.outputs.api_url }}" \
+            "${{ vars.API_ENDPOINT || '/api/v1/image' }}"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,41 @@
+version: "2"
+
+linters:
+  default: standard
+  enable:
+    - bodyclose
+    - errcheck
+    - govet
+    - ineffassign
+    - misspell
+    - revive
+    - staticcheck
+    - unconvert
+    - unused
+
+  settings:
+    errcheck:
+      # Closing a response body in a defer has no useful error to act on, and
+      # writes to an in-process io.Writer cannot meaningfully fail.
+      exclude-functions:
+        - (io.ReadCloser).Close
+        - (io.Closer).Close
+    revive:
+      rules:
+        - name: exported
+          arguments:
+            - disableStutteringCheck
+
+  exclusions:
+    rules:
+      # Progress output goes to an io.Writer that never fails in practice;
+      # checking every Fprintf would bury the actual logic.
+      - linters: [errcheck]
+        source: "^\\s*fmt\\.Fprint(f|ln)?\\("
+      # Test helpers deliberately construct odd inputs.
+      - linters: [errcheck]
+        path: _test\.go
+
+formatters:
+  enable:
+    - gofmt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,124 @@
+# Contributing to Eagle Image API
+
+Thanks for taking the time to contribute. This document covers how to get a
+development environment running, what the project expects from a change, and
+how a pull request gets reviewed.
+
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Getting set up
+
+Eagle wraps [libvips](https://www.libvips.org/) through
+[govips](https://github.com/davidbyttow/govips), so cgo and a local libvips
+install are required — a plain `go build` fails without them.
+
+```bash
+# macOS
+brew install vips pkg-config
+
+# Debian / Ubuntu
+sudo apt-get install -y libvips-dev pkg-config
+```
+
+Then clone and verify the toolchain:
+
+```bash
+git clone https://github.com/nicobistolfi/eagle-image-api.git
+cd eagle-image-api
+go build ./...
+go test ./...
+```
+
+The repository uses [Task](https://taskfile.dev) as its task runner. `task
+--list` shows the available targets; `task test` and `task build` are the two
+you will use most.
+
+## Making a change
+
+1. Open an issue first for anything larger than a bug fix or a small
+   improvement. Agreeing on the approach before code is written saves
+   everyone time.
+2. Branch off `main`. Name the branch after what it does, e.g.
+   `fix/avif-timeout` or `feat/webp-effort-flag`.
+3. Keep the change focused. Unrelated refactors belong in their own pull
+   request, where they can be reviewed on their own merits.
+
+## What a change needs
+
+Before opening a pull request, make sure all of the following pass. CI runs
+exactly these checks, so a green local run means a green pipeline.
+
+```bash
+go build ./...
+go test -race ./...
+go vet ./...
+gofmt -l .              # must print nothing
+staticcheck ./...
+golangci-lint run ./...
+```
+
+Beyond the tooling:
+
+- **Tests.** New behaviour needs tests, and bug fixes need a test that fails
+  without the fix. The project holds statement coverage at 80% or above; the
+  Codecov check on your pull request reports where you landed.
+- **Documentation comments.** Every exported identifier needs a doc comment
+  starting with its name, because these are published on
+  [pkg.go.dev](https://pkg.go.dev/github.com/nicobistolfi/eagle-image-api).
+- **Errors.** Wrap with `fmt.Errorf("doing the thing: %w", err)` so the
+  failure path reads as a sentence. Do not discard errors silently.
+- **README.** Update it when you add or change a query parameter, an
+  environment variable, or a CLI flag.
+
+### Testing against libvips
+
+Image tests run against real libvips rather than a mock, and fixtures are
+generated with the standard library's `image/png` encoder instead of embedded
+blobs. libvips decodes lazily, so a malformed fixture will not fail on load —
+it fails much later, during export, with a confusing error. Generate real
+pixel data.
+
+If your libvips build lacks an encoder (AVIF is the usual one), the affected
+tests skip rather than fail.
+
+## Commit messages
+
+Write a short imperative summary line, then a body explaining *why* the change
+is needed if that is not obvious from the summary. Reference the issue the
+change closes.
+
+```
+Fix AVIF encoding timeout on large images
+
+Images above the configured megapixel ceiling took longer to encode than the
+Lambda timeout allowed, so the request failed instead of falling back. Skip
+AVIF for those and serve WebP.
+
+Closes #42
+```
+
+## Pull requests
+
+Open the pull request against `main` and fill in what changed and why. A
+maintainer reviews it, and CI must be green before it can merge. Expect review
+comments — they are about the code, not about you.
+
+Pull requests are squash-merged, so the pull request title becomes the commit
+message on `main`. Give it the same care as a commit summary.
+
+## Releases
+
+Releases are cut by maintainers by pushing a SemVer tag:
+
+```bash
+git tag -a v1.2.3 -m "v1.2.3"
+git push origin v1.2.3
+```
+
+This triggers GoReleaser, which builds the `eagle` CLI for macOS and Linux,
+publishes the archives to the GitHub release, and updates the Homebrew tap.
+
+## Reporting security issues
+
+Do not open a public issue for a security vulnerability. Follow the process in
+[SECURITY.md](SECURITY.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,20 @@ pixel data.
 If your libvips build lacks an encoder (AVIF is the usual one), the affected
 tests skip rather than fail.
 
+### Smoke testing a deployment
+
+`scripts/smoke-test.sh` checks that a deployed instance is actually serving:
+health endpoint, a real transformation, WebP negotiation from the `Accept`
+header, and the error paths. CI runs it against the dev stack after every
+deploy, and you can point it at any deployment:
+
+```bash
+scripts/smoke-test.sh https://your-deployment.example.com
+```
+
+It is deliberately shallow — it proves the stack is wired together, not that
+every transformation is correct. The Go tests cover the latter.
+
 ## Commit messages
 
 Write a short imperative summary line, then a body explaining *why* the change

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 
 RUN apt-get update && apt-get install -y libvips-dev
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.24
+FROM golang:1.25
 
 RUN apt-get update && apt-get install -y libvips-dev
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/nicobistolfi/eagle-image-api)](https://goreportcard.com/report/github.com/nicobistolfi/eagle-image-api)
 [![Go Reference](https://pkg.go.dev/badge/github.com/nicobistolfi/eagle-image-api.svg)](https://pkg.go.dev/github.com/nicobistolfi/eagle-image-api)
 [![Build Status](https://github.com/nicobistolfi/eagle-image-api/actions/workflows/ci.yml/badge.svg)](https://github.com/nicobistolfi/eagle-image-api/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/nicobistolfi/eagle-image-api/branch/main/graph/badge.svg)](https://codecov.io/gh/nicobistolfi/eagle-image-api)
 [![Postman](https://img.shields.io/badge/Postman-Run%20in%20Postman-orange)](https://god.gw.postman.com/run-collection/22482580-83154c76-0cda-4385-848b-bdaa0bef7fb8?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D22482580-83154c76-0cda-4385-848b-bdaa0bef7fb8%26entityType%3Dcollection%26workspaceId%3Dfa758360-633e-4980-857e-9500b71c1d81)
 
-Free and open source Image Optimization & Transformation API built in Go using [govips](https://github.com/davidbyttow/govips) (libvips) and [Serverless](https://serverless.com/). Ready to be deployed on AWS Lambda and CloudFront.
+Free and open source Image Optimization & Transformation API built in Go using [govips](https://github.com/davidbyttow/govips) (libvips) and AWS CloudFormation. Ready to be deployed on AWS Lambda and CloudFront.
 
 ## How to deploy to AWS and Run
 [![How to deploy to AWS and Run - Watch Video](https://cdn.loom.com/sessions/thumbnails/97692855cf3947eabd45dd5e90a548ec-c333bef1399a2164-full-play.gif)](https://www.loom.com/share/97692855cf3947eabd45dd5e90a548ec)
@@ -29,6 +30,8 @@ Free and open source Image Optimization & Transformation API built in Go using [
     - [Resize and crop with position top](#resize-and-crop-with-position-top)
     - [Resize and crop with position and quality](#resize-and-crop-with-position-and-quality)
     - [Lossless compression](#lossless-compression)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Eagle CLI
 
@@ -81,11 +84,11 @@ AWS credentials are read from the standard credential chain (environment variabl
 
 ### Prerequisites
 
-- Go 1.22+
-- libvips 8.10+ (`brew install vips` on macOS, `apt install libvips-dev` on Ubuntu)
+- Go 1.25+
+- libvips 8.10+ (`brew install vips pkg-config` on macOS, `apt install libvips-dev pkg-config` on Ubuntu)
 - [Task](https://taskfile.dev/) (`go install github.com/go-task/task/v3/cmd/task@latest` or `brew install go-task`)
 - Docker (for deployment)
-- Serverless Framework (`npm install -g serverless`)
+- AWS credentials with permission to manage CloudFormation, ECR, Lambda, API Gateway, and CloudFront (for deployment)
 
 ### Setting up .env file
 
@@ -145,15 +148,30 @@ Photo by <a href="https://unsplash.com/@buchstabenhausen?utm_content=creditCopyT
 
 ### Deploy to AWS
 
-The API is deployed as a Docker container on AWS Lambda via Serverless Framework.
+The API runs as a Docker container on AWS Lambda, fronted by API Gateway and
+CloudFront. The whole stack is described in [`template.yml`](template.yml) and
+deployed with the `eagle` CLI:
 
 ```bash
-# Deploy to dev (via Serverless Framework)
-sls deploy --stage dev
+# Deploy to dev
+eagle deploy --stage dev
 
-# Deploy to production (via Serverless Framework)
-sls deploy --stage production
+# Deploy to production
+eagle deploy --stage prod
 ```
+
+To deploy the template directly instead of using the CLI:
+
+```bash
+aws cloudformation deploy \
+  --template-file template.yml \
+  --stack-name eagle-image-api-dev \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides Stage=dev ImageUri=<your-ecr-image-uri>
+```
+
+Pushes to `main` deploy production automatically through
+[`.github/workflows/deploy-main.yml`](.github/workflows/deploy-main.yml).
 
 ### Run in Postman
 
@@ -251,3 +269,33 @@ For the purpose of this test we set quality=10 just to test it, normally you sho
 <img src="https://d2xjbqad0ryx9j.cloudfront.net/api/v1/image?width=400&quality=80&loseless=true&url=https%3A%2F%2Feagle-image-test.s3.us-west-1.amazonaws.com%2Fpublic%2Feagle-2.jpg" width="200px" alt="Resized image" />
 
 [View original api response here](https://d2xjbqad0ryx9j.cloudfront.net/api/v1/image?width=400&quality=80&loseless=true&url=https%3A%2F%2Feagle-image-test.s3.us-west-1.amazonaws.com%2Fpublic%2Feagle-2.jpg)
+
+## Contributing
+
+Contributions are welcome. [CONTRIBUTING.md](CONTRIBUTING.md) covers setting up
+a development environment (libvips and cgo are required), the checks a change
+needs to pass, and how pull requests are reviewed.
+
+Building the project needs libvips installed locally:
+
+```bash
+# macOS
+brew install vips pkg-config
+
+# Debian / Ubuntu
+sudo apt-get install -y libvips-dev pkg-config
+```
+
+Then:
+
+```bash
+go build ./...
+go test -race ./...
+```
+
+For a security vulnerability, please follow [SECURITY.md](SECURITY.md) rather
+than opening a public issue.
+
+## License
+
+Released under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied to the latest released version. Please upgrade to
+the most recent release before reporting an issue.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest release | Yes |
+| Older releases | No |
+
+## Reporting a vulnerability
+
+Please do not open a public issue for a security vulnerability.
+
+Report it through GitHub's private reporting form at
+[Security > Report a vulnerability](https://github.com/nicobistolfi/eagle-image-api/security/advisories/new),
+which opens a private advisory visible only to the maintainers.
+
+Include what you can:
+
+- The version or commit affected
+- What an attacker can do with it
+- Steps to reproduce, ideally a request that demonstrates the problem
+- Any suggested fix
+
+You can expect an acknowledgement within a week. Once a fix is ready it ships
+in a patch release, and the advisory is published crediting you unless you
+prefer otherwise.
+
+## Scope
+
+Eagle fetches images from URLs supplied in the request, so the areas most
+worth scrutiny are:
+
+- The origin allowlist (`ORIGIN_WHITELIST`) and any way to bypass it
+- Server-side request forgery through the `url` parameter
+- Resource exhaustion via crafted images or transformation parameters
+- Anything that lets a request reach the AWS credentials the Lambda runs with
+
+Reports about a deployment's own misconfiguration — for example running with
+`ORIGIN_WHITELIST=*` on a private network — are worth discussing in a public
+issue instead, since the fix is documentation rather than code.

--- a/cmd/eagle/main.go
+++ b/cmd/eagle/main.go
@@ -1,41 +1,31 @@
+// Command eagle deploys the Eagle Image Optimization API to AWS.
+//
+// Usage:
+//
+//	eagle deploy --stage prod --region us-west-1
+//
+// Run `eagle deploy --help` for the full list of deployment parameters.
 package main
 
 import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
-	"github.com/zantez/image-api/internal/commands"
+	"github.com/nicobistolfi/eagle-image-api/internal/commands"
 )
 
+// Build metadata, injected at release time via -ldflags -X.
 var (
 	version = "dev"
 	commit  = "none"
 	date    = "unknown"
 )
 
-var showVersion bool
-
-var rootCmd = &cobra.Command{
-	Use:   "eagle",
-	Short: "Eagle - Image Optimization API CLI",
-	Long:  "Eagle CLI allows you to deploy the Eagle Image Optimization API to AWS with a single command.",
-	Run: func(cmd *cobra.Command, args []string) {
-		if showVersion {
-			fmt.Printf("eagle %s (commit: %s, built: %s)\n", version, commit, date)
-			return
-		}
-		_ = cmd.Help()
-	},
-}
-
-func init() {
-	rootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "Show version, commit, and build date")
-	rootCmd.AddCommand(commands.DeployCmd)
-}
-
 func main() {
-	if err := rootCmd.Execute(); err != nil {
+	commands.SetBuildInfo(version, commit, date)
+
+	if err := commands.NewRootCmd().Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/eagle/main_test.go
+++ b/cmd/eagle/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nicobistolfi/eagle-image-api/internal/commands"
+)
+
+// TestBuildInfoIsForwarded checks the ldflags-injected version metadata
+// reaches the CLI, which is what `eagle --version` prints.
+func TestBuildInfoIsForwarded(t *testing.T) {
+	t.Cleanup(func() { commands.SetBuildInfo(version, commit, date) })
+
+	commands.SetBuildInfo(version, commit, date)
+
+	got := commands.VersionString()
+	for _, want := range []string{version, commit, date} {
+		if !strings.Contains(got, want) {
+			t.Errorf("VersionString() = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
+// TestDefaultBuildInfo documents the values a `go build` (no ldflags) leaves
+// in place, so a broken release pipeline is visible rather than silent.
+func TestDefaultBuildInfo(t *testing.T) {
+	if version != "dev" {
+		t.Errorf("version = %q, want dev as the un-injected default", version)
+	}
+	if commit != "none" {
+		t.Errorf("commit = %q, want none as the un-injected default", commit)
+	}
+	if date != "unknown" {
+		t.Errorf("date = %q, want unknown as the un-injected default", date)
+	}
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+# Codecov configuration. See https://docs.codecov.com/docs/codecov-yaml
+coverage:
+  status:
+    project:
+      default:
+        # awesome-go asks for at least 80% coverage; hold the line there
+        # rather than at whatever the current number happens to be.
+        target: 80%
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        threshold: 5%
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: true

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zantez/image-api
+module github.com/nicobistolfi/eagle-image-api
 
 go 1.24
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nicobistolfi/eagle-image-api
 
-go 1.24
+go 1.25.0
 
 require (
 	github.com/aws/aws-lambda-go v1.54.0
@@ -27,7 +27,7 @@ require (
 	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	golang.org/x/image v0.18.0 // indirect
+	golang.org/x/image v0.43.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/text v0.23.0 // indirect
+	golang.org/x/text v0.38.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -49,12 +49,12 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/image v0.18.0 h1:jGzIakQa/ZXI1I0Fxvaa9W7yP25TqT6cHIHn+6CqvSQ=
-golang.org/x/image v0.18.0/go.mod h1:4yyo5vMFQjVjUcVk4jEQcU9MGy/rulF5WvUILseCM2E=
+golang.org/x/image v0.43.0 h1:FLxcP4ec2350nTfOC8ysKtqYSIFbk/QGjw1ZHNP4tsY=
+golang.org/x/image v0.43.0/go.mod h1:rrpelvGFt+kLPAjPM4HeWPgrl0FtafueU//e5N0qk/Q=
 golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
 golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
-golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
-golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
+golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
+golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/commands/deploy.go
+++ b/internal/commands/deploy.go
@@ -21,11 +21,52 @@ import (
 )
 
 const (
-	defaultTemplateURL = "https://raw.githubusercontent.com/nicobistolfi/eagle-image-api/main/template.yml"
-	dockerHubImage     = "nicobistolfi/eagle-image-api:latest"
-	ecrRepoName        = "eagle-image-api"
+	// DefaultTemplateURL is where the CloudFormation template is fetched from
+	// when --template is not supplied.
+	DefaultTemplateURL = "https://raw.githubusercontent.com/nicobistolfi/eagle-image-api/main/template.yml"
+
+	// DockerHubRepo is the published image repository mirrored into the
+	// user's own ECR registry before deployment.
+	DockerHubRepo = "nicobistolfi/eagle-image-api"
+
+	// ECRRepoName is the repository created in the target AWS account.
+	ECRRepoName = "eagle-image-api"
+
+	// stackPollInterval is how long to wait between stack status checks.
+	stackPollInterval = 10 * time.Second
 )
 
+// templateURL and templateClient are variables rather than constants so tests
+// can point the fetch at a local server.
+var (
+	templateURL    = DefaultTemplateURL
+	templateClient = &http.Client{Timeout: 30 * time.Second}
+)
+
+// ecrAPI is the subset of the ECR client the deploy command uses. Depending on
+// an interface rather than *ecr.Client keeps the deployment logic testable
+// without AWS credentials.
+type ecrAPI interface {
+	DescribeRepositories(ctx context.Context, in *ecr.DescribeRepositoriesInput, opts ...func(*ecr.Options)) (*ecr.DescribeRepositoriesOutput, error)
+	CreateRepository(ctx context.Context, in *ecr.CreateRepositoryInput, opts ...func(*ecr.Options)) (*ecr.CreateRepositoryOutput, error)
+	GetAuthorizationToken(ctx context.Context, in *ecr.GetAuthorizationTokenInput, opts ...func(*ecr.Options)) (*ecr.GetAuthorizationTokenOutput, error)
+}
+
+// cfnAPI is the subset of the CloudFormation client the deploy command uses.
+type cfnAPI interface {
+	DescribeStacks(ctx context.Context, in *cloudformation.DescribeStacksInput, opts ...func(*cloudformation.Options)) (*cloudformation.DescribeStacksOutput, error)
+	CreateStack(ctx context.Context, in *cloudformation.CreateStackInput, opts ...func(*cloudformation.Options)) (*cloudformation.CreateStackOutput, error)
+	UpdateStack(ctx context.Context, in *cloudformation.UpdateStackInput, opts ...func(*cloudformation.Options)) (*cloudformation.UpdateStackOutput, error)
+}
+
+// dockerRunner executes a docker subcommand. The stdin argument, when
+// non-empty, is piped to the process — used to feed the ECR password to
+// `docker login --password-stdin` so it never appears in the process list.
+type dockerRunner func(stdin string, args ...string) error
+
+// deployFlags mirrors the command line flags of the deploy command. Every
+// value is a string because it is forwarded verbatim as a CloudFormation
+// parameter, which is string-typed.
 type deployFlags struct {
 	stage           string
 	region          string
@@ -45,6 +86,18 @@ type deployFlags struct {
 
 var flags deployFlags
 
+// deployer carries the collaborators a deployment needs. Tests construct one
+// with fakes; runDeploy builds one backed by the real AWS SDK clients.
+type deployer struct {
+	ecr    ecrAPI
+	cfn    cfnAPI
+	docker dockerRunner
+	out    io.Writer
+	sleep  func(time.Duration)
+	flags  deployFlags
+}
+
+// DeployCmd deploys the Eagle Image API to AWS via CloudFormation.
 var DeployCmd = &cobra.Command{
 	Use:   "deploy",
 	Short: "Deploy Eagle Image API to AWS",
@@ -55,63 +108,89 @@ pushes the Docker Hub image to your ECR, and deploys the stack.
 
 AWS credentials are read from the standard AWS credential chain
 (environment variables, ~/.aws/credentials, IAM role).`,
-	RunE: runDeploy,
+	RunE:         runDeploy,
+	SilenceUsage: true,
 }
 
 func init() {
-	f := DeployCmd.Flags()
-	f.StringVar(&flags.stage, "stage", "dev", "Deployment stage (sets Stage parameter and stack name)")
-	f.StringVar(&flags.region, "region", "us-west-1", "AWS region")
-	f.StringVar(&flags.template, "template", "", "Path to local CloudFormation template (default: fetched from GitHub)")
-	f.StringVar(&flags.quality, "quality", "80", "Image quality (0-100)")
-	f.StringVar(&flags.fit, "fit", "outside", "Default resize fit mode")
-	f.StringVar(&flags.logLevel, "log-level", "info", "Log level (error/warn/info/debug)")
-	f.StringVar(&flags.originWhitelist, "origin-whitelist", "*", "Comma-separated origin whitelist")
-	f.StringVar(&flags.redirectOnError, "redirect-on-error", "false", "Redirect to original image on error")
-	f.StringVar(&flags.webp, "webp", "true", "Enable WebP format")
-	f.StringVar(&flags.avif, "avif", "true", "Enable AVIF format")
-	f.StringVar(&flags.avifMaxMp, "avif-max-mp", "2", "Maximum megapixels for AVIF output")
-	f.StringVar(&flags.environment, "environment", "production", "Environment name")
-	f.StringVar(&flags.apiEndpoint, "api-endpoint", "/api/v1/image", "API endpoint path")
-	f.StringVar(&flags.imageTag, "image-tag", "latest", "Docker Hub image tag to deploy")
+	registerDeployFlags(DeployCmd, &flags)
 }
 
-func runDeploy(cmd *cobra.Command, args []string) error {
-	ctx := context.Background()
+// registerDeployFlags binds every deploy flag to dst. It is split out from
+// init so tests can build an independent command with its own flag storage.
+func registerDeployFlags(cmd *cobra.Command, dst *deployFlags) {
+	f := cmd.Flags()
+	f.StringVar(&dst.stage, "stage", "dev", "Deployment stage (sets Stage parameter and stack name)")
+	f.StringVar(&dst.region, "region", "us-west-1", "AWS region")
+	f.StringVar(&dst.template, "template", "", "Path to local CloudFormation template (default: fetched from GitHub)")
+	f.StringVar(&dst.quality, "quality", "80", "Image quality (0-100)")
+	f.StringVar(&dst.fit, "fit", "outside", "Default resize fit mode")
+	f.StringVar(&dst.logLevel, "log-level", "info", "Log level (error/warn/info/debug)")
+	f.StringVar(&dst.originWhitelist, "origin-whitelist", "*", "Comma-separated origin whitelist")
+	f.StringVar(&dst.redirectOnError, "redirect-on-error", "false", "Redirect to original image on error")
+	f.StringVar(&dst.webp, "webp", "true", "Enable WebP format")
+	f.StringVar(&dst.avif, "avif", "true", "Enable AVIF format")
+	f.StringVar(&dst.avifMaxMp, "avif-max-mp", "2", "Maximum megapixels for AVIF output")
+	f.StringVar(&dst.environment, "environment", "production", "Environment name")
+	f.StringVar(&dst.apiEndpoint, "api-endpoint", "/api/v1/image", "API endpoint path")
+	f.StringVar(&dst.imageTag, "image-tag", "latest", "Docker Hub image tag to deploy")
+}
 
-	// Load AWS config
+func runDeploy(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(flags.region))
 	if err != nil {
 		return fmt.Errorf("loading AWS config: %w", err)
 	}
 
-	// Get CloudFormation template body
-	templateBody, err := getTemplateBody(flags.template)
+	d := &deployer{
+		ecr:    ecr.NewFromConfig(cfg),
+		cfn:    cloudformation.NewFromConfig(cfg),
+		docker: runDockerCmd,
+		out:    cmd.OutOrStdout(),
+		sleep:  time.Sleep,
+		flags:  flags,
+	}
+
+	return d.run(ctx)
+}
+
+// run performs the full deployment: fetch template, mirror the image into
+// ECR, then create or update the CloudFormation stack.
+func (d *deployer) run(ctx context.Context) error {
+	templateBody, err := getTemplateBody(d.flags.template)
 	if err != nil {
 		return fmt.Errorf("getting template: %w", err)
 	}
 
-	// Set up ECR and push image
-	fmt.Println("Setting up ECR repository...")
-	imageURI, err := setupECRAndPushImage(ctx, cfg)
+	fmt.Fprintln(d.out, "Setting up ECR repository...")
+	imageURI, err := d.setupECRAndPushImage(ctx)
 	if err != nil {
 		return fmt.Errorf("setting up ECR image: %w", err)
 	}
-	fmt.Printf("Image pushed to: %s\n", imageURI)
+	fmt.Fprintf(d.out, "Image pushed to: %s\n", imageURI)
 
-	// Deploy CloudFormation stack
-	stackName := fmt.Sprintf("eagle-image-api-%s", flags.stage)
-	fmt.Printf("Deploying stack %q in %s...\n", stackName, flags.region)
+	name := stackName(d.flags.stage)
+	fmt.Fprintf(d.out, "Deploying stack %q in %s...\n", name, d.flags.region)
 
-	err = deployStack(ctx, cfg, stackName, templateBody, imageURI)
-	if err != nil {
+	if err := d.deployStack(ctx, name, templateBody, imageURI); err != nil {
 		return fmt.Errorf("deploying stack: %w", err)
 	}
 
-	// Print outputs
-	return printStackOutputs(ctx, cfg, stackName)
+	return d.printStackOutputs(ctx, name)
 }
 
+// stackName derives the CloudFormation stack name for a deployment stage.
+func stackName(stage string) string {
+	return fmt.Sprintf("eagle-image-api-%s", stage)
+}
+
+// getTemplateBody returns the CloudFormation template, read from localPath
+// when set and otherwise downloaded from the project repository.
 func getTemplateBody(localPath string) (string, error) {
 	if localPath != "" {
 		data, err := os.ReadFile(localPath)
@@ -121,8 +200,12 @@ func getTemplateBody(localPath string) (string, error) {
 		return string(data), nil
 	}
 
-	fmt.Println("Fetching CloudFormation template from GitHub...")
-	resp, err := http.Get(defaultTemplateURL)
+	req, err := http.NewRequest(http.MethodGet, templateURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("building template request: %w", err)
+	}
+
+	resp, err := templateClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("fetching template: %w", err)
 	}
@@ -139,71 +222,74 @@ func getTemplateBody(localPath string) (string, error) {
 	return string(data), nil
 }
 
-func setupECRAndPushImage(ctx context.Context, cfg aws.Config) (string, error) {
-	ecrClient := ecr.NewFromConfig(cfg)
-
-	// Create ECR repository if it doesn't exist
-	repoURI, err := ensureECRRepo(ctx, ecrClient)
+// setupECRAndPushImage ensures the ECR repository exists and mirrors the
+// published Docker Hub image into it, returning the pushed image URI.
+func (d *deployer) setupECRAndPushImage(ctx context.Context) (string, error) {
+	repoURI, err := d.ensureECRRepo(ctx)
 	if err != nil {
 		return "", err
 	}
 
-	// Get ECR auth token
-	authToken, endpoint, err := getECRAuth(ctx, ecrClient)
+	authToken, endpoint, err := d.getECRAuth(ctx)
 	if err != nil {
 		return "", fmt.Errorf("getting ECR auth: %w", err)
 	}
 
-	// Docker login to ECR
-	if err := dockerLogin(authToken, endpoint); err != nil {
+	username, password, err := decodeAuthToken(authToken)
+	if err != nil {
+		return "", fmt.Errorf("docker login to ECR: %w", err)
+	}
+	if err := d.docker(password, "login", "--username", username, "--password-stdin", endpoint); err != nil {
 		return "", fmt.Errorf("docker login to ECR: %w", err)
 	}
 
-	sourceImage := fmt.Sprintf("nicobistolfi/eagle-image-api:%s", flags.imageTag)
-	targetImage := fmt.Sprintf("%s:%s", repoURI, flags.imageTag)
+	sourceImage := fmt.Sprintf("%s:%s", DockerHubRepo, d.flags.imageTag)
+	targetImage := fmt.Sprintf("%s:%s", repoURI, d.flags.imageTag)
 
-	// Pull from Docker Hub
-	fmt.Printf("Pulling %s...\n", sourceImage)
-	if err := runDockerCmd("pull", sourceImage); err != nil {
+	fmt.Fprintf(d.out, "Pulling %s...\n", sourceImage)
+	if err := d.docker("", "pull", sourceImage); err != nil {
 		return "", fmt.Errorf("pulling image: %w", err)
 	}
 
-	// Tag for ECR
-	if err := runDockerCmd("tag", sourceImage, targetImage); err != nil {
+	if err := d.docker("", "tag", sourceImage, targetImage); err != nil {
 		return "", fmt.Errorf("tagging image: %w", err)
 	}
 
-	// Push to ECR
-	fmt.Printf("Pushing to ECR: %s...\n", targetImage)
-	if err := runDockerCmd("push", targetImage); err != nil {
+	fmt.Fprintf(d.out, "Pushing to ECR: %s...\n", targetImage)
+	if err := d.docker("", "push", targetImage); err != nil {
 		return "", fmt.Errorf("pushing image to ECR: %w", err)
 	}
 
 	return targetImage, nil
 }
 
-func ensureECRRepo(ctx context.Context, client *ecr.Client) (string, error) {
-	desc, err := client.DescribeRepositories(ctx, &ecr.DescribeRepositoriesInput{
-		RepositoryNames: []string{ecrRepoName},
+// ensureECRRepo returns the URI of the ECR repository, creating it when the
+// describe call reports it missing.
+func (d *deployer) ensureECRRepo(ctx context.Context) (string, error) {
+	desc, err := d.ecr.DescribeRepositories(ctx, &ecr.DescribeRepositoriesInput{
+		RepositoryNames: []string{ECRRepoName},
 	})
 	if err == nil && len(desc.Repositories) > 0 {
 		return aws.ToString(desc.Repositories[0].RepositoryUri), nil
 	}
 
-	// Create the repository
-	fmt.Printf("Creating ECR repository %q...\n", ecrRepoName)
-	out, err := client.CreateRepository(ctx, &ecr.CreateRepositoryInput{
-		RepositoryName:     aws.String(ecrRepoName),
+	fmt.Fprintf(d.out, "Creating ECR repository %q...\n", ECRRepoName)
+	out, err := d.ecr.CreateRepository(ctx, &ecr.CreateRepositoryInput{
+		RepositoryName:     aws.String(ECRRepoName),
 		ImageTagMutability: ecrtypes.ImageTagMutabilityMutable,
 	})
 	if err != nil {
 		return "", fmt.Errorf("creating ECR repository: %w", err)
 	}
+	if out.Repository == nil {
+		return "", fmt.Errorf("creating ECR repository: no repository returned")
+	}
 	return aws.ToString(out.Repository.RepositoryUri), nil
 }
 
-func getECRAuth(ctx context.Context, client *ecr.Client) (string, string, error) {
-	out, err := client.GetAuthorizationToken(ctx, &ecr.GetAuthorizationTokenInput{})
+// getECRAuth returns the base64 authorization token and registry endpoint.
+func (d *deployer) getECRAuth(ctx context.Context) (string, string, error) {
+	out, err := d.ecr.GetAuthorizationToken(ctx, &ecr.GetAuthorizationTokenInput{})
 	if err != nil {
 		return "", "", err
 	}
@@ -214,157 +300,199 @@ func getECRAuth(ctx context.Context, client *ecr.Client) (string, string, error)
 	return aws.ToString(auth.AuthorizationToken), aws.ToString(auth.ProxyEndpoint), nil
 }
 
-func dockerLogin(authToken, endpoint string) error {
+// decodeAuthToken splits an ECR authorization token into username and
+// password. The token is base64 of "user:password".
+func decodeAuthToken(authToken string) (username, password string, err error) {
 	decoded, err := base64.StdEncoding.DecodeString(authToken)
 	if err != nil {
-		return fmt.Errorf("decoding auth token: %w", err)
+		return "", "", fmt.Errorf("decoding auth token: %w", err)
 	}
 	parts := strings.SplitN(string(decoded), ":", 2)
 	if len(parts) != 2 {
-		return fmt.Errorf("unexpected auth token format")
+		return "", "", fmt.Errorf("unexpected auth token format")
 	}
-
-	cmd := exec.Command("docker", "login", "--username", parts[0], "--password-stdin", endpoint)
-	cmd.Stdin = strings.NewReader(parts[1])
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	return parts[0], parts[1], nil
 }
 
-func runDockerCmd(args ...string) error {
+// runDockerCmd shells out to the docker binary, piping stdin when non-empty.
+func runDockerCmd(stdin string, args ...string) error {
 	cmd := exec.Command("docker", args...)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
 
-func deployStack(ctx context.Context, cfg aws.Config, stackName, templateBody, imageURI string) error {
-	cfClient := cloudformation.NewFromConfig(cfg)
-
-	params := []cftypes.Parameter{
-		{ParameterKey: aws.String("Stage"), ParameterValue: aws.String(flags.stage)},
-		{ParameterKey: aws.String("ImageUri"), ParameterValue: aws.String(imageURI)},
-		{ParameterKey: aws.String("Environment"), ParameterValue: aws.String(flags.environment)},
-		{ParameterKey: aws.String("ApiEndpoint"), ParameterValue: aws.String(flags.apiEndpoint)},
-		{ParameterKey: aws.String("Quality"), ParameterValue: aws.String(flags.quality)},
-		{ParameterKey: aws.String("Fit"), ParameterValue: aws.String(flags.fit)},
-		{ParameterKey: aws.String("LogLevel"), ParameterValue: aws.String(flags.logLevel)},
-		{ParameterKey: aws.String("OriginWhitelist"), ParameterValue: aws.String(flags.originWhitelist)},
-		{ParameterKey: aws.String("RedirectOnError"), ParameterValue: aws.String(flags.redirectOnError)},
-		{ParameterKey: aws.String("WebP"), ParameterValue: aws.String(flags.webp)},
-		{ParameterKey: aws.String("Avif"), ParameterValue: aws.String(flags.avif)},
-		{ParameterKey: aws.String("AvifMaxMp"), ParameterValue: aws.String(flags.avifMaxMp)},
+// buildParameters maps the deploy flags onto the CloudFormation parameters
+// declared in template.yml. Order is fixed to keep the mapping reviewable.
+func buildParameters(f deployFlags, imageURI string) []cftypes.Parameter {
+	pairs := []struct{ key, value string }{
+		{"Stage", f.stage},
+		{"ImageUri", imageURI},
+		{"Environment", f.environment},
+		{"ApiEndpoint", f.apiEndpoint},
+		{"Quality", f.quality},
+		{"Fit", f.fit},
+		{"LogLevel", f.logLevel},
+		{"OriginWhitelist", f.originWhitelist},
+		{"RedirectOnError", f.redirectOnError},
+		{"WebP", f.webp},
+		{"Avif", f.avif},
+		{"AvifMaxMp", f.avifMaxMp},
 	}
 
-	// Check if stack exists
-	_, err := cfClient.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
-		StackName: aws.String(stackName),
+	params := make([]cftypes.Parameter, 0, len(pairs))
+	for _, p := range pairs {
+		params = append(params, cftypes.Parameter{
+			ParameterKey:   aws.String(p.key),
+			ParameterValue: aws.String(p.value),
+		})
+	}
+	return params
+}
+
+// buildTags returns the tags applied to the CloudFormation stack.
+func buildTags(f deployFlags) []cftypes.Tag {
+	return []cftypes.Tag{
+		{Key: aws.String("Project"), Value: aws.String("eagle-image-api")},
+		{Key: aws.String("Stage"), Value: aws.String(f.stage)},
+		{Key: aws.String("ManagedBy"), Value: aws.String("eagle-cli")},
+	}
+}
+
+// deployStack creates the stack, or updates it when it already exists, then
+// blocks until CloudFormation reaches a terminal status.
+func (d *deployer) deployStack(ctx context.Context, name, templateBody, imageURI string) error {
+	params := buildParameters(d.flags, imageURI)
+	tags := buildTags(d.flags)
+	capabilities := []cftypes.Capability{cftypes.CapabilityCapabilityNamedIam}
+
+	_, err := d.cfn.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
+		StackName: aws.String(name),
 	})
 
 	if err != nil {
-		// Stack doesn't exist, create it
-		fmt.Println("Creating new stack...")
-		_, err = cfClient.CreateStack(ctx, &cloudformation.CreateStackInput{
-			StackName:    aws.String(stackName),
+		fmt.Fprintln(d.out, "Creating new stack...")
+		_, err = d.cfn.CreateStack(ctx, &cloudformation.CreateStackInput{
+			StackName:    aws.String(name),
 			TemplateBody: aws.String(templateBody),
 			Parameters:   params,
-			Capabilities: []cftypes.Capability{cftypes.CapabilityCapabilityNamedIam},
-			Tags: []cftypes.Tag{
-				{Key: aws.String("Project"), Value: aws.String("eagle-image-api")},
-				{Key: aws.String("Stage"), Value: aws.String(flags.stage)},
-				{Key: aws.String("ManagedBy"), Value: aws.String("eagle-cli")},
-			},
+			Capabilities: capabilities,
+			Tags:         tags,
 		})
 		if err != nil {
 			return fmt.Errorf("creating stack: %w", err)
 		}
-		fmt.Println("Waiting for stack creation to complete...")
-		return waitForStack(ctx, cfClient, stackName)
+		fmt.Fprintln(d.out, "Waiting for stack creation to complete...")
+		return d.waitForStack(ctx, name)
 	}
 
-	// Stack exists, update it
-	fmt.Println("Updating existing stack...")
-	_, err = cfClient.UpdateStack(ctx, &cloudformation.UpdateStackInput{
-		StackName:    aws.String(stackName),
+	fmt.Fprintln(d.out, "Updating existing stack...")
+	_, err = d.cfn.UpdateStack(ctx, &cloudformation.UpdateStackInput{
+		StackName:    aws.String(name),
 		TemplateBody: aws.String(templateBody),
 		Parameters:   params,
-		Capabilities: []cftypes.Capability{cftypes.CapabilityCapabilityNamedIam},
-		Tags: []cftypes.Tag{
-			{Key: aws.String("Project"), Value: aws.String("eagle-image-api")},
-			{Key: aws.String("Stage"), Value: aws.String(flags.stage)},
-			{Key: aws.String("ManagedBy"), Value: aws.String("eagle-cli")},
-		},
+		Capabilities: capabilities,
+		Tags:         tags,
 	})
 	if err != nil {
 		if strings.Contains(err.Error(), "No updates are to be performed") {
-			fmt.Println("Stack is already up to date.")
+			fmt.Fprintln(d.out, "Stack is already up to date.")
 			return nil
 		}
 		return fmt.Errorf("updating stack: %w", err)
 	}
-	fmt.Println("Waiting for stack update to complete...")
-	return waitForStack(ctx, cfClient, stackName)
+	fmt.Fprintln(d.out, "Waiting for stack update to complete...")
+	return d.waitForStack(ctx, name)
 }
 
-func waitForStack(ctx context.Context, client *cloudformation.Client, stackName string) error {
+// isTerminalFailure reports whether a stack status means the deployment ended
+// without success and no further polling will help.
+func isTerminalFailure(status cftypes.StackStatus) bool {
+	switch status {
+	case cftypes.StackStatusCreateFailed,
+		cftypes.StackStatusRollbackComplete,
+		cftypes.StackStatusRollbackFailed,
+		cftypes.StackStatusUpdateRollbackComplete,
+		cftypes.StackStatusUpdateRollbackFailed,
+		cftypes.StackStatusDeleteComplete,
+		cftypes.StackStatusDeleteFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+// isTerminalSuccess reports whether a stack status means the deployment
+// finished successfully.
+func isTerminalSuccess(status cftypes.StackStatus) bool {
+	return status == cftypes.StackStatusCreateComplete ||
+		status == cftypes.StackStatusUpdateComplete
+}
+
+// waitForStack polls the stack until it succeeds, fails, or ctx is done.
+func (d *deployer) waitForStack(ctx context.Context, name string) error {
 	for {
-		out, err := client.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
-			StackName: aws.String(stackName),
+		out, err := d.cfn.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
+			StackName: aws.String(name),
 		})
 		if err != nil {
 			return fmt.Errorf("describing stack: %w", err)
 		}
 		if len(out.Stacks) == 0 {
-			return fmt.Errorf("stack %q not found", stackName)
+			return fmt.Errorf("stack %q not found", name)
 		}
 
-		status := out.Stacks[0].StackStatus
-		switch status {
-		case cftypes.StackStatusCreateComplete, cftypes.StackStatusUpdateComplete:
-			fmt.Printf("Stack %s completed successfully.\n", status)
+		stack := out.Stacks[0]
+		status := stack.StackStatus
+
+		switch {
+		case isTerminalSuccess(status):
+			fmt.Fprintf(d.out, "Stack %s completed successfully.\n", status)
 			return nil
-		case cftypes.StackStatusCreateFailed, cftypes.StackStatusRollbackComplete,
-			cftypes.StackStatusRollbackFailed, cftypes.StackStatusUpdateRollbackComplete,
-			cftypes.StackStatusUpdateRollbackFailed, cftypes.StackStatusDeleteComplete,
-			cftypes.StackStatusDeleteFailed:
+		case isTerminalFailure(status):
 			reason := ""
-			if out.Stacks[0].StackStatusReason != nil {
-				reason = ": " + *out.Stacks[0].StackStatusReason
+			if stack.StackStatusReason != nil {
+				reason = ": " + *stack.StackStatusReason
 			}
 			return fmt.Errorf("stack reached terminal status %s%s", status, reason)
-		default:
-			fmt.Printf("  Status: %s...\n", status)
-			time.Sleep(10 * time.Second)
 		}
+
+		fmt.Fprintf(d.out, "  Status: %s...\n", status)
+
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		d.sleep(stackPollInterval)
 	}
 }
 
-func printStackOutputs(ctx context.Context, cfg aws.Config, stackName string) error {
-	cfClient := cloudformation.NewFromConfig(cfg)
-	out, err := cfClient.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
-		StackName: aws.String(stackName),
+// printStackOutputs writes the stack outputs, highlighting the two URLs a
+// user needs after a successful deployment.
+func (d *deployer) printStackOutputs(ctx context.Context, name string) error {
+	out, err := d.cfn.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
+		StackName: aws.String(name),
 	})
 	if err != nil {
 		return fmt.Errorf("describing stack outputs: %w", err)
 	}
 	if len(out.Stacks) == 0 {
-		return fmt.Errorf("stack %q not found", stackName)
+		return fmt.Errorf("stack %q not found", name)
 	}
 
-	fmt.Println("\n=== Deployment Outputs ===")
+	fmt.Fprintln(d.out, "\n=== Deployment Outputs ===")
 	for _, output := range out.Stacks[0].Outputs {
-		fmt.Printf("  %s: %s\n", aws.ToString(output.OutputKey), aws.ToString(output.OutputValue))
+		fmt.Fprintf(d.out, "  %s: %s\n", aws.ToString(output.OutputKey), aws.ToString(output.OutputValue))
 	}
 
-	// Print user-friendly summary
 	for _, output := range out.Stacks[0].Outputs {
-		key := aws.ToString(output.OutputKey)
-		val := aws.ToString(output.OutputValue)
-		switch key {
+		switch aws.ToString(output.OutputKey) {
 		case "ApiUrl":
-			fmt.Printf("\nAPI Gateway URL: %s\n", val)
+			fmt.Fprintf(d.out, "\nAPI Gateway URL: %s\n", aws.ToString(output.OutputValue))
 		case "CloudFrontUrl":
-			fmt.Printf("CloudFront URL:  %s\n", val)
+			fmt.Fprintf(d.out, "CloudFront URL:  %s\n", aws.ToString(output.OutputValue))
 		}
 	}
 

--- a/internal/commands/deploy_test.go
+++ b/internal/commands/deploy_test.go
@@ -1,40 +1,160 @@
 package commands
 
 import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
 )
 
-func TestDeployCmd_Flags(t *testing.T) {
-	// Verify all expected flags exist with correct defaults
-	tests := []struct {
-		name         string
-		flag         string
-		defaultValue string
-	}{
-		{"stage", "stage", "dev"},
-		{"region", "region", "us-west-1"},
-		{"template", "template", ""},
-		{"quality", "quality", "80"},
-		{"fit", "fit", "outside"},
-		{"log-level", "log-level", "info"},
-		{"origin-whitelist", "origin-whitelist", "*"},
-		{"redirect-on-error", "redirect-on-error", "false"},
-		{"webp", "webp", "true"},
-		{"avif", "avif", "true"},
-		{"avif-max-mp", "avif-max-mp", "2"},
-		{"environment", "environment", "production"},
-		{"api-endpoint", "api-endpoint", "/api/v1/image"},
-		{"image-tag", "image-tag", "latest"},
+// awsNoUpdatesMessage is the error CloudFormation returns for a no-op update.
+// deployStack matches on this text, so the exact wording matters.
+const awsNoUpdatesMessage = "ValidationError: No updates are to be performed."
+
+// --- fakes -----------------------------------------------------------------
+
+type fakeECR struct {
+	describeOut *ecr.DescribeRepositoriesOutput
+	describeErr error
+	createOut   *ecr.CreateRepositoryOutput
+	createErr   error
+	authOut     *ecr.GetAuthorizationTokenOutput
+	authErr     error
+
+	createCalls int
+}
+
+func (f *fakeECR) DescribeRepositories(context.Context, *ecr.DescribeRepositoriesInput, ...func(*ecr.Options)) (*ecr.DescribeRepositoriesOutput, error) {
+	return f.describeOut, f.describeErr
+}
+
+func (f *fakeECR) CreateRepository(context.Context, *ecr.CreateRepositoryInput, ...func(*ecr.Options)) (*ecr.CreateRepositoryOutput, error) {
+	f.createCalls++
+	return f.createOut, f.createErr
+}
+
+func (f *fakeECR) GetAuthorizationToken(context.Context, *ecr.GetAuthorizationTokenInput, ...func(*ecr.Options)) (*ecr.GetAuthorizationTokenOutput, error) {
+	return f.authOut, f.authErr
+}
+
+// fakeCFN replays a queued sequence of DescribeStacks results so a test can
+// model a stack that progresses through several statuses.
+type fakeCFN struct {
+	describeQueue []describeResult
+	describeCalls int
+
+	createErr error
+	updateErr error
+
+	created bool
+	updated bool
+}
+
+type describeResult struct {
+	out *cloudformation.DescribeStacksOutput
+	err error
+}
+
+func (f *fakeCFN) DescribeStacks(context.Context, *cloudformation.DescribeStacksInput, ...func(*cloudformation.Options)) (*cloudformation.DescribeStacksOutput, error) {
+	i := f.describeCalls
+	f.describeCalls++
+	if i >= len(f.describeQueue) {
+		i = len(f.describeQueue) - 1
+	}
+	if i < 0 {
+		return nil, errors.New("no describe results queued")
+	}
+	r := f.describeQueue[i]
+	return r.out, r.err
+}
+
+func (f *fakeCFN) CreateStack(context.Context, *cloudformation.CreateStackInput, ...func(*cloudformation.Options)) (*cloudformation.CreateStackOutput, error) {
+	f.created = true
+	return &cloudformation.CreateStackOutput{}, f.createErr
+}
+
+func (f *fakeCFN) UpdateStack(context.Context, *cloudformation.UpdateStackInput, ...func(*cloudformation.Options)) (*cloudformation.UpdateStackOutput, error) {
+	f.updated = true
+	return &cloudformation.UpdateStackOutput{}, f.updateErr
+}
+
+// recordingDocker captures the docker invocations instead of running them.
+type recordingDocker struct {
+	calls [][]string
+	stdin []string
+	err   error
+}
+
+func (r *recordingDocker) run(stdin string, args ...string) error {
+	r.calls = append(r.calls, args)
+	r.stdin = append(r.stdin, stdin)
+	return r.err
+}
+
+func stackOutput(status cftypes.StackStatus, reason string, outputs ...cftypes.Output) *cloudformation.DescribeStacksOutput {
+	s := cftypes.Stack{StackStatus: status, Outputs: outputs}
+	if reason != "" {
+		s.StackStatusReason = aws.String(reason)
+	}
+	return &cloudformation.DescribeStacksOutput{Stacks: []cftypes.Stack{s}}
+}
+
+func testFlags() deployFlags {
+	return deployFlags{
+		stage: "dev", region: "us-west-1", quality: "80", fit: "outside",
+		logLevel: "info", originWhitelist: "*", redirectOnError: "false",
+		webp: "true", avif: "true", avifMaxMp: "2", environment: "production",
+		apiEndpoint: "/api/v1/image", imageTag: "latest",
+	}
+}
+
+func newTestDeployer(e ecrAPI, c cfnAPI, d dockerRunner) (*deployer, *bytes.Buffer) {
+	var buf bytes.Buffer
+	return &deployer{
+		ecr:    e,
+		cfn:    c,
+		docker: d,
+		out:    &buf,
+		sleep:  func(time.Duration) {}, // never actually sleep in tests
+		flags:  testFlags(),
+	}, &buf
+}
+
+// --- flag wiring -----------------------------------------------------------
+
+func TestDeployCmdFlags(t *testing.T) {
+	tests := []struct{ flag, defaultValue string }{
+		{"stage", "dev"},
+		{"region", "us-west-1"},
+		{"template", ""},
+		{"quality", "80"},
+		{"fit", "outside"},
+		{"log-level", "info"},
+		{"origin-whitelist", "*"},
+		{"redirect-on-error", "false"},
+		{"webp", "true"},
+		{"avif", "true"},
+		{"avif-max-mp", "2"},
+		{"environment", "production"},
+		{"api-endpoint", "/api/v1/image"},
+		{"image-tag", "latest"},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.flag, func(t *testing.T) {
 			f := DeployCmd.Flags().Lookup(tt.flag)
 			if f == nil {
 				t.Fatalf("flag %q not found", tt.flag)
@@ -46,26 +166,44 @@ func TestDeployCmd_Flags(t *testing.T) {
 	}
 }
 
-func TestDeployCmd_HelpOutput(t *testing.T) {
-	// Verify the command has proper use and short description
+func TestDeployCmdMetadata(t *testing.T) {
 	if DeployCmd.Use != "deploy" {
-		t.Errorf("Use = %q, want %q", DeployCmd.Use, "deploy")
+		t.Errorf("Use = %q, want deploy", DeployCmd.Use)
 	}
 	if DeployCmd.Short == "" {
 		t.Error("Short description should not be empty")
 	}
+	if DeployCmd.Long == "" {
+		t.Error("Long description should not be empty")
+	}
 }
 
-func TestGetTemplateBody_LocalFile(t *testing.T) {
-	// Create a temp file with template content
-	dir := t.TempDir()
-	templatePath := filepath.Join(dir, "template.yml")
+func TestRegisterDeployFlagsBindsValues(t *testing.T) {
+	cmd, dst := newDeployCmdForTest()
+	if err := cmd.Flags().Set("stage", "prod"); err != nil {
+		t.Fatalf("setting stage: %v", err)
+	}
+	if err := cmd.Flags().Set("avif-max-mp", "8"); err != nil {
+		t.Fatalf("setting avif-max-mp: %v", err)
+	}
+	if dst.stage != "prod" {
+		t.Errorf("stage = %q, want prod", dst.stage)
+	}
+	if dst.avifMaxMp != "8" {
+		t.Errorf("avifMaxMp = %q, want 8", dst.avifMaxMp)
+	}
+}
+
+// --- template fetching -----------------------------------------------------
+
+func TestGetTemplateBodyLocalFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "template.yml")
 	content := "AWSTemplateFormatVersion: '2010-09-09'\nDescription: Test template"
-	if err := os.WriteFile(templatePath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("writing temp file: %v", err)
 	}
 
-	body, err := getTemplateBody(templatePath)
+	body, err := getTemplateBody(path)
 	if err != nil {
 		t.Fatalf("getTemplateBody() error: %v", err)
 	}
@@ -74,88 +212,763 @@ func TestGetTemplateBody_LocalFile(t *testing.T) {
 	}
 }
 
-func TestGetTemplateBody_LocalFileNotFound(t *testing.T) {
-	_, err := getTemplateBody("/nonexistent/template.yml")
-	if err == nil {
-		t.Fatal("expected error for nonexistent file")
+func TestGetTemplateBodyLocalFileNotFound(t *testing.T) {
+	if _, err := getTemplateBody(filepath.Join(t.TempDir(), "missing.yml")); err == nil {
+		t.Fatal("expected an error for a nonexistent file")
 	}
 }
 
-func TestGetTemplateBody_RemoteFetch(t *testing.T) {
-	expected := "AWSTemplateFormatVersion: '2010-09-09'\nDescription: Remote template"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
+func TestGetTemplateBodyRemoteFetch(t *testing.T) {
+	const expected = "AWSTemplateFormatVersion: '2010-09-09'"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(expected))
 	}))
-	defer server.Close()
+	defer srv.Close()
 
-	// We can't easily override the URL constant, so just test the local path case
-	// and verify the function signature works for remote (tested via integration)
+	restore := swapTemplateURL(t, srv.URL)
+	defer restore()
+
 	body, err := getTemplateBody("")
-	// This will try to fetch from GitHub which may fail in CI, that's expected
 	if err != nil {
-		t.Skipf("skipping remote fetch test (network not available): %v", err)
+		t.Fatalf("getTemplateBody() error: %v", err)
 	}
-	if body == "" {
-		t.Error("expected non-empty template body from remote fetch")
+	if body != expected {
+		t.Errorf("body = %q, want %q", body, expected)
 	}
 }
 
-func TestParameterMapping(t *testing.T) {
-	// Verify the CloudFormation parameter keys match template.yml parameters
-	expectedParams := []string{
+func TestGetTemplateBodyRemoteNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	restore := swapTemplateURL(t, srv.URL)
+	defer restore()
+
+	_, err := getTemplateBody("")
+	if err == nil {
+		t.Fatal("expected an error for HTTP 404")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("error = %v, want it to mention the status code", err)
+	}
+}
+
+func TestGetTemplateBodyRemoteUnreachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close() // nothing is listening now
+
+	restore := swapTemplateURL(t, url)
+	defer restore()
+
+	if _, err := getTemplateBody(""); err == nil {
+		t.Fatal("expected an error when the server is unreachable")
+	}
+}
+
+func TestDefaultTemplateURLPointsAtRepo(t *testing.T) {
+	if !strings.Contains(DefaultTemplateURL, "nicobistolfi/eagle-image-api") {
+		t.Errorf("DefaultTemplateURL = %q, want it to reference the project repo", DefaultTemplateURL)
+	}
+	if !strings.HasSuffix(DefaultTemplateURL, "template.yml") {
+		t.Errorf("DefaultTemplateURL = %q, want it to end in template.yml", DefaultTemplateURL)
+	}
+}
+
+// --- ECR -------------------------------------------------------------------
+
+func TestEnsureECRRepoExisting(t *testing.T) {
+	e := &fakeECR{describeOut: &ecr.DescribeRepositoriesOutput{
+		Repositories: []ecrtypes.Repository{{RepositoryUri: aws.String("123.dkr.ecr.us-west-1.amazonaws.com/eagle-image-api")}},
+	}}
+	d, _ := newTestDeployer(e, &fakeCFN{}, (&recordingDocker{}).run)
+
+	uri, err := d.ensureECRRepo(context.Background())
+	if err != nil {
+		t.Fatalf("ensureECRRepo() error: %v", err)
+	}
+	if uri != "123.dkr.ecr.us-west-1.amazonaws.com/eagle-image-api" {
+		t.Errorf("uri = %q", uri)
+	}
+	if e.createCalls != 0 {
+		t.Errorf("CreateRepository called %d times, want 0 for an existing repo", e.createCalls)
+	}
+}
+
+func TestEnsureECRRepoCreatesWhenMissing(t *testing.T) {
+	e := &fakeECR{
+		describeErr: errors.New("RepositoryNotFoundException"),
+		createOut: &ecr.CreateRepositoryOutput{
+			Repository: &ecrtypes.Repository{RepositoryUri: aws.String("123.dkr.ecr.us-west-1.amazonaws.com/eagle-image-api")},
+		},
+	}
+	d, out := newTestDeployer(e, &fakeCFN{}, (&recordingDocker{}).run)
+
+	uri, err := d.ensureECRRepo(context.Background())
+	if err != nil {
+		t.Fatalf("ensureECRRepo() error: %v", err)
+	}
+	if uri == "" {
+		t.Error("expected a repository URI")
+	}
+	if e.createCalls != 1 {
+		t.Errorf("CreateRepository called %d times, want 1", e.createCalls)
+	}
+	if !strings.Contains(out.String(), "Creating ECR repository") {
+		t.Errorf("expected progress output, got %q", out.String())
+	}
+}
+
+func TestEnsureECRRepoCreateFails(t *testing.T) {
+	e := &fakeECR{
+		describeErr: errors.New("not found"),
+		createErr:   errors.New("AccessDenied"),
+	}
+	d, _ := newTestDeployer(e, &fakeCFN{}, (&recordingDocker{}).run)
+
+	_, err := d.ensureECRRepo(context.Background())
+	if err == nil {
+		t.Fatal("expected an error when CreateRepository fails")
+	}
+	if !strings.Contains(err.Error(), "AccessDenied") {
+		t.Errorf("error = %v, want it to wrap the AWS error", err)
+	}
+}
+
+func TestEnsureECRRepoCreateReturnsNoRepository(t *testing.T) {
+	e := &fakeECR{
+		describeErr: errors.New("not found"),
+		createOut:   &ecr.CreateRepositoryOutput{}, // Repository is nil
+	}
+	d, _ := newTestDeployer(e, &fakeCFN{}, (&recordingDocker{}).run)
+
+	if _, err := d.ensureECRRepo(context.Background()); err == nil {
+		t.Fatal("expected an error when CreateRepository returns no repository")
+	}
+}
+
+func TestGetECRAuth(t *testing.T) {
+	e := &fakeECR{authOut: &ecr.GetAuthorizationTokenOutput{
+		AuthorizationData: []ecrtypes.AuthorizationData{{
+			AuthorizationToken: aws.String("dG9rZW4="),
+			ProxyEndpoint:      aws.String("https://123.dkr.ecr.us-west-1.amazonaws.com"),
+		}},
+	}}
+	d, _ := newTestDeployer(e, &fakeCFN{}, (&recordingDocker{}).run)
+
+	token, endpoint, err := d.getECRAuth(context.Background())
+	if err != nil {
+		t.Fatalf("getECRAuth() error: %v", err)
+	}
+	if token != "dG9rZW4=" {
+		t.Errorf("token = %q", token)
+	}
+	if endpoint != "https://123.dkr.ecr.us-west-1.amazonaws.com" {
+		t.Errorf("endpoint = %q", endpoint)
+	}
+}
+
+func TestGetECRAuthErrors(t *testing.T) {
+	t.Run("api error", func(t *testing.T) {
+		d, _ := newTestDeployer(&fakeECR{authErr: errors.New("boom")}, &fakeCFN{}, (&recordingDocker{}).run)
+		if _, _, err := d.getECRAuth(context.Background()); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+
+	t.Run("empty authorization data", func(t *testing.T) {
+		e := &fakeECR{authOut: &ecr.GetAuthorizationTokenOutput{}}
+		d, _ := newTestDeployer(e, &fakeCFN{}, (&recordingDocker{}).run)
+		_, _, err := d.getECRAuth(context.Background())
+		if err == nil {
+			t.Fatal("expected an error for empty authorization data")
+		}
+	})
+}
+
+func TestDecodeAuthToken(t *testing.T) {
+	token := base64.StdEncoding.EncodeToString([]byte("AWS:secret:with:colons"))
+
+	user, pass, err := decodeAuthToken(token)
+	if err != nil {
+		t.Fatalf("decodeAuthToken() error: %v", err)
+	}
+	if user != "AWS" {
+		t.Errorf("user = %q, want AWS", user)
+	}
+	// SplitN with n=2 must keep colons in the password intact.
+	if pass != "secret:with:colons" {
+		t.Errorf("pass = %q, want secret:with:colons", pass)
+	}
+}
+
+func TestDecodeAuthTokenInvalid(t *testing.T) {
+	t.Run("not base64", func(t *testing.T) {
+		if _, _, err := decodeAuthToken("!!!not base64!!!"); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+
+	t.Run("missing separator", func(t *testing.T) {
+		token := base64.StdEncoding.EncodeToString([]byte("no-colon-here"))
+		if _, _, err := decodeAuthToken(token); err == nil {
+			t.Fatal("expected an error for a token without a colon")
+		}
+	})
+}
+
+func TestSetupECRAndPushImage(t *testing.T) {
+	e := &fakeECR{
+		describeOut: &ecr.DescribeRepositoriesOutput{
+			Repositories: []ecrtypes.Repository{{RepositoryUri: aws.String("123.dkr.ecr.us-west-1.amazonaws.com/eagle-image-api")}},
+		},
+		authOut: &ecr.GetAuthorizationTokenOutput{
+			AuthorizationData: []ecrtypes.AuthorizationData{{
+				AuthorizationToken: aws.String(base64.StdEncoding.EncodeToString([]byte("AWS:pw"))),
+				ProxyEndpoint:      aws.String("https://123.dkr.ecr.us-west-1.amazonaws.com"),
+			}},
+		},
+	}
+	docker := &recordingDocker{}
+	d, _ := newTestDeployer(e, &fakeCFN{}, docker.run)
+
+	uri, err := d.setupECRAndPushImage(context.Background())
+	if err != nil {
+		t.Fatalf("setupECRAndPushImage() error: %v", err)
+	}
+	if want := "123.dkr.ecr.us-west-1.amazonaws.com/eagle-image-api:latest"; uri != want {
+		t.Errorf("uri = %q, want %q", uri, want)
+	}
+
+	if len(docker.calls) != 4 {
+		t.Fatalf("docker called %d times, want 4 (login, pull, tag, push)", len(docker.calls))
+	}
+	for i, want := range []string{"login", "pull", "tag", "push"} {
+		if docker.calls[i][0] != want {
+			t.Errorf("docker call %d = %q, want %q", i, docker.calls[i][0], want)
+		}
+	}
+	// The password must arrive over stdin, never as an argv element.
+	if docker.stdin[0] != "pw" {
+		t.Errorf("login stdin = %q, want the password", docker.stdin[0])
+	}
+	if strings.Contains(strings.Join(docker.calls[0], " "), "pw") {
+		t.Error("password leaked into docker login arguments")
+	}
+}
+
+func TestSetupECRAndPushImageDockerFailure(t *testing.T) {
+	e := &fakeECR{
+		describeOut: &ecr.DescribeRepositoriesOutput{
+			Repositories: []ecrtypes.Repository{{RepositoryUri: aws.String("repo")}},
+		},
+		authOut: &ecr.GetAuthorizationTokenOutput{
+			AuthorizationData: []ecrtypes.AuthorizationData{{
+				AuthorizationToken: aws.String(base64.StdEncoding.EncodeToString([]byte("AWS:pw"))),
+				ProxyEndpoint:      aws.String("endpoint"),
+			}},
+		},
+	}
+	docker := &recordingDocker{err: errors.New("docker daemon not running")}
+	d, _ := newTestDeployer(e, &fakeCFN{}, docker.run)
+
+	_, err := d.setupECRAndPushImage(context.Background())
+	if err == nil {
+		t.Fatal("expected an error when docker fails")
+	}
+	if !strings.Contains(err.Error(), "docker login") {
+		t.Errorf("error = %v, want it to identify the failing docker step", err)
+	}
+}
+
+func TestSetupECRAndPushImageAuthFailure(t *testing.T) {
+	e := &fakeECR{
+		describeOut: &ecr.DescribeRepositoriesOutput{
+			Repositories: []ecrtypes.Repository{{RepositoryUri: aws.String("repo")}},
+		},
+		authErr: errors.New("expired credentials"),
+	}
+	d, _ := newTestDeployer(e, &fakeCFN{}, (&recordingDocker{}).run)
+
+	if _, err := d.setupECRAndPushImage(context.Background()); err == nil {
+		t.Fatal("expected an error when the auth call fails")
+	}
+}
+
+func TestSetupECRAndPushImageBadAuthToken(t *testing.T) {
+	e := &fakeECR{
+		describeOut: &ecr.DescribeRepositoriesOutput{
+			Repositories: []ecrtypes.Repository{{RepositoryUri: aws.String("repo")}},
+		},
+		authOut: &ecr.GetAuthorizationTokenOutput{
+			AuthorizationData: []ecrtypes.AuthorizationData{{
+				AuthorizationToken: aws.String("!!!"),
+				ProxyEndpoint:      aws.String("endpoint"),
+			}},
+		},
+	}
+	d, _ := newTestDeployer(e, &fakeCFN{}, (&recordingDocker{}).run)
+
+	if _, err := d.setupECRAndPushImage(context.Background()); err == nil {
+		t.Fatal("expected an error for an undecodable auth token")
+	}
+}
+
+func TestSetupECRAndPushImageRepoFailure(t *testing.T) {
+	e := &fakeECR{describeErr: errors.New("nope"), createErr: errors.New("denied")}
+	d, _ := newTestDeployer(e, &fakeCFN{}, (&recordingDocker{}).run)
+
+	if _, err := d.setupECRAndPushImage(context.Background()); err == nil {
+		t.Fatal("expected an error when the repository cannot be resolved")
+	}
+}
+
+// --- parameters and tags ---------------------------------------------------
+
+func TestBuildParameters(t *testing.T) {
+	f := testFlags()
+	f.stage = "prod"
+	f.quality = "95"
+
+	params := buildParameters(f, "123.dkr.ecr.us-west-1.amazonaws.com/eagle:latest")
+
+	// Keys must match the parameters declared in template.yml exactly.
+	wantKeys := []string{
 		"Stage", "ImageUri", "Environment", "ApiEndpoint",
 		"Quality", "Fit", "LogLevel", "OriginWhitelist",
 		"RedirectOnError", "WebP", "Avif", "AvifMaxMp",
 	}
-
-	// Build params using the same logic as deployStack
-	params := []cftypes.Parameter{
-		{ParameterKey: strPtr("Stage"), ParameterValue: strPtr("dev")},
-		{ParameterKey: strPtr("ImageUri"), ParameterValue: strPtr("test:latest")},
-		{ParameterKey: strPtr("Environment"), ParameterValue: strPtr("production")},
-		{ParameterKey: strPtr("ApiEndpoint"), ParameterValue: strPtr("/api/v1/image")},
-		{ParameterKey: strPtr("Quality"), ParameterValue: strPtr("80")},
-		{ParameterKey: strPtr("Fit"), ParameterValue: strPtr("outside")},
-		{ParameterKey: strPtr("LogLevel"), ParameterValue: strPtr("info")},
-		{ParameterKey: strPtr("OriginWhitelist"), ParameterValue: strPtr("*")},
-		{ParameterKey: strPtr("RedirectOnError"), ParameterValue: strPtr("false")},
-		{ParameterKey: strPtr("WebP"), ParameterValue: strPtr("true")},
-		{ParameterKey: strPtr("Avif"), ParameterValue: strPtr("true")},
-		{ParameterKey: strPtr("AvifMaxMp"), ParameterValue: strPtr("2")},
+	if len(params) != len(wantKeys) {
+		t.Fatalf("got %d parameters, want %d", len(params), len(wantKeys))
 	}
 
-	if len(params) != len(expectedParams) {
-		t.Fatalf("param count = %d, want %d", len(params), len(expectedParams))
-	}
-
+	got := map[string]string{}
 	for i, p := range params {
-		if *p.ParameterKey != expectedParams[i] {
-			t.Errorf("param[%d] key = %q, want %q", i, *p.ParameterKey, expectedParams[i])
+		if aws.ToString(p.ParameterKey) != wantKeys[i] {
+			t.Errorf("param[%d] key = %q, want %q", i, aws.ToString(p.ParameterKey), wantKeys[i])
+		}
+		got[aws.ToString(p.ParameterKey)] = aws.ToString(p.ParameterValue)
+	}
+
+	if got["Stage"] != "prod" {
+		t.Errorf("Stage = %q, want prod", got["Stage"])
+	}
+	if got["Quality"] != "95" {
+		t.Errorf("Quality = %q, want 95", got["Quality"])
+	}
+	if got["ImageUri"] != "123.dkr.ecr.us-west-1.amazonaws.com/eagle:latest" {
+		t.Errorf("ImageUri = %q", got["ImageUri"])
+	}
+}
+
+// TestBuildParametersMatchTemplate guards against the parameter list drifting
+// away from the CloudFormation template checked into the repository.
+func TestBuildParametersMatchTemplate(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "template.yml"))
+	if err != nil {
+		t.Skipf("template.yml not readable: %v", err)
+	}
+	template := string(data)
+
+	for _, p := range buildParameters(testFlags(), "img") {
+		key := aws.ToString(p.ParameterKey)
+		if !strings.Contains(template, "\n  "+key+":") {
+			t.Errorf("parameter %q is sent to CloudFormation but not declared in template.yml", key)
 		}
 	}
 }
 
-func TestStackNameFormat(t *testing.T) {
-	tests := []struct {
-		stage    string
-		expected string
-	}{
+func TestBuildTags(t *testing.T) {
+	f := testFlags()
+	f.stage = "staging"
+
+	tags := map[string]string{}
+	for _, tag := range buildTags(f) {
+		tags[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+	}
+
+	if tags["Project"] != "eagle-image-api" {
+		t.Errorf("Project tag = %q", tags["Project"])
+	}
+	if tags["Stage"] != "staging" {
+		t.Errorf("Stage tag = %q, want staging", tags["Stage"])
+	}
+	if tags["ManagedBy"] != "eagle-cli" {
+		t.Errorf("ManagedBy tag = %q", tags["ManagedBy"])
+	}
+}
+
+func TestStackName(t *testing.T) {
+	tests := []struct{ stage, want string }{
 		{"dev", "eagle-image-api-dev"},
 		{"prod", "eagle-image-api-prod"},
 		{"staging", "eagle-image-api-staging"},
 	}
-
 	for _, tt := range tests {
-		t.Run(tt.stage, func(t *testing.T) {
-			name := "eagle-image-api-" + tt.stage
-			if name != tt.expected {
-				t.Errorf("stack name = %q, want %q", name, tt.expected)
-			}
-		})
+		if got := stackName(tt.stage); got != tt.want {
+			t.Errorf("stackName(%q) = %q, want %q", tt.stage, got, tt.want)
+		}
 	}
 }
 
-func strPtr(s string) *string {
-	return &s
+// --- stack lifecycle -------------------------------------------------------
+
+func TestDeployStackCreatesWhenMissing(t *testing.T) {
+	c := &fakeCFN{describeQueue: []describeResult{
+		{err: errors.New("stack does not exist")},                 // existence probe
+		{out: stackOutput(cftypes.StackStatusCreateComplete, "")}, // wait
+	}}
+	d, out := newTestDeployer(&fakeECR{}, c, (&recordingDocker{}).run)
+
+	if err := d.deployStack(context.Background(), "eagle-image-api-dev", "body", "img"); err != nil {
+		t.Fatalf("deployStack() error: %v", err)
+	}
+	if !c.created {
+		t.Error("expected CreateStack to be called")
+	}
+	if c.updated {
+		t.Error("UpdateStack should not be called for a missing stack")
+	}
+	if !strings.Contains(out.String(), "Creating new stack") {
+		t.Errorf("expected create progress output, got %q", out.String())
+	}
+}
+
+func TestDeployStackUpdatesWhenPresent(t *testing.T) {
+	c := &fakeCFN{describeQueue: []describeResult{
+		{out: stackOutput(cftypes.StackStatusCreateComplete, "")}, // exists
+		{out: stackOutput(cftypes.StackStatusUpdateComplete, "")}, // wait
+	}}
+	d, _ := newTestDeployer(&fakeECR{}, c, (&recordingDocker{}).run)
+
+	if err := d.deployStack(context.Background(), "eagle-image-api-dev", "body", "img"); err != nil {
+		t.Fatalf("deployStack() error: %v", err)
+	}
+	if !c.updated {
+		t.Error("expected UpdateStack to be called")
+	}
+	if c.created {
+		t.Error("CreateStack should not be called for an existing stack")
+	}
+}
+
+func TestDeployStackNoUpdatesNeeded(t *testing.T) {
+	c := &fakeCFN{
+		describeQueue: []describeResult{{out: stackOutput(cftypes.StackStatusCreateComplete, "")}},
+		updateErr:     errors.New(awsNoUpdatesMessage),
+	}
+	d, out := newTestDeployer(&fakeECR{}, c, (&recordingDocker{}).run)
+
+	// A no-op update is success, not failure.
+	if err := d.deployStack(context.Background(), "eagle-image-api-dev", "body", "img"); err != nil {
+		t.Fatalf("deployStack() error: %v", err)
+	}
+	if !strings.Contains(out.String(), "already up to date") {
+		t.Errorf("expected an up-to-date message, got %q", out.String())
+	}
+}
+
+func TestDeployStackUpdateFails(t *testing.T) {
+	c := &fakeCFN{
+		describeQueue: []describeResult{{out: stackOutput(cftypes.StackStatusCreateComplete, "")}},
+		updateErr:     errors.New("InsufficientCapabilities"),
+	}
+	d, _ := newTestDeployer(&fakeECR{}, c, (&recordingDocker{}).run)
+
+	if err := d.deployStack(context.Background(), "eagle-image-api-dev", "body", "img"); err == nil {
+		t.Fatal("expected an error when UpdateStack fails")
+	}
+}
+
+func TestDeployStackCreateFails(t *testing.T) {
+	c := &fakeCFN{
+		describeQueue: []describeResult{{err: errors.New("missing")}},
+		createErr:     errors.New("AlreadyExistsException"),
+	}
+	d, _ := newTestDeployer(&fakeECR{}, c, (&recordingDocker{}).run)
+
+	if err := d.deployStack(context.Background(), "eagle-image-api-dev", "body", "img"); err == nil {
+		t.Fatal("expected an error when CreateStack fails")
+	}
+}
+
+func TestWaitForStackPollsUntilComplete(t *testing.T) {
+	c := &fakeCFN{describeQueue: []describeResult{
+		{out: stackOutput(cftypes.StackStatusCreateInProgress, "")},
+		{out: stackOutput(cftypes.StackStatusCreateInProgress, "")},
+		{out: stackOutput(cftypes.StackStatusCreateComplete, "")},
+	}}
+	d, out := newTestDeployer(&fakeECR{}, c, (&recordingDocker{}).run)
+
+	slept := 0
+	d.sleep = func(time.Duration) { slept++ }
+
+	if err := d.waitForStack(context.Background(), "eagle-image-api-dev"); err != nil {
+		t.Fatalf("waitForStack() error: %v", err)
+	}
+	if slept != 2 {
+		t.Errorf("slept %d times, want 2 (once per in-progress poll)", slept)
+	}
+	if !strings.Contains(out.String(), "completed successfully") {
+		t.Errorf("expected a success message, got %q", out.String())
+	}
+}
+
+func TestWaitForStackTerminalFailure(t *testing.T) {
+	c := &fakeCFN{describeQueue: []describeResult{
+		{out: stackOutput(cftypes.StackStatusRollbackComplete, "resource creation failed")},
+	}}
+	d, _ := newTestDeployer(&fakeECR{}, c, (&recordingDocker{}).run)
+
+	err := d.waitForStack(context.Background(), "eagle-image-api-dev")
+	if err == nil {
+		t.Fatal("expected an error for a rolled-back stack")
+	}
+	if !strings.Contains(err.Error(), "resource creation failed") {
+		t.Errorf("error = %v, want it to include the CloudFormation reason", err)
+	}
+}
+
+func TestWaitForStackTerminalFailureWithoutReason(t *testing.T) {
+	c := &fakeCFN{describeQueue: []describeResult{
+		{out: stackOutput(cftypes.StackStatusCreateFailed, "")},
+	}}
+	d, _ := newTestDeployer(&fakeECR{}, c, (&recordingDocker{}).run)
+
+	if err := d.waitForStack(context.Background(), "eagle-image-api-dev"); err == nil {
+		t.Fatal("expected an error for a failed stack")
+	}
+}
+
+func TestWaitForStackDescribeError(t *testing.T) {
+	c := &fakeCFN{describeQueue: []describeResult{{err: errors.New("throttled")}}}
+	d, _ := newTestDeployer(&fakeECR{}, c, (&recordingDocker{}).run)
+
+	if err := d.waitForStack(context.Background(), "eagle-image-api-dev"); err == nil {
+		t.Fatal("expected an error when DescribeStacks fails")
+	}
+}
+
+func TestWaitForStackNoStacksReturned(t *testing.T) {
+	c := &fakeCFN{describeQueue: []describeResult{{out: &cloudformation.DescribeStacksOutput{}}}}
+	d, _ := newTestDeployer(&fakeECR{}, c, (&recordingDocker{}).run)
+
+	if err := d.waitForStack(context.Background(), "eagle-image-api-dev"); err == nil {
+		t.Fatal("expected an error when no stacks are returned")
+	}
+}
+
+func TestWaitForStackHonoursContextCancellation(t *testing.T) {
+	// A stack stuck in progress must not poll forever once the caller gives up.
+	c := &fakeCFN{describeQueue: []describeResult{
+		{out: stackOutput(cftypes.StackStatusCreateInProgress, "")},
+	}}
+	d, _ := newTestDeployer(&fakeECR{}, c, (&recordingDocker{}).run)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := d.waitForStack(ctx, "eagle-image-api-dev"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForStack() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestStackStatusClassification(t *testing.T) {
+	success := []cftypes.StackStatus{
+		cftypes.StackStatusCreateComplete,
+		cftypes.StackStatusUpdateComplete,
+	}
+	failure := []cftypes.StackStatus{
+		cftypes.StackStatusCreateFailed,
+		cftypes.StackStatusRollbackComplete,
+		cftypes.StackStatusRollbackFailed,
+		cftypes.StackStatusUpdateRollbackComplete,
+		cftypes.StackStatusUpdateRollbackFailed,
+		cftypes.StackStatusDeleteComplete,
+		cftypes.StackStatusDeleteFailed,
+	}
+	pending := []cftypes.StackStatus{
+		cftypes.StackStatusCreateInProgress,
+		cftypes.StackStatusUpdateInProgress,
+		cftypes.StackStatusDeleteInProgress,
+	}
+
+	for _, s := range success {
+		if !isTerminalSuccess(s) || isTerminalFailure(s) {
+			t.Errorf("%s should classify as terminal success", s)
+		}
+	}
+	for _, s := range failure {
+		if !isTerminalFailure(s) || isTerminalSuccess(s) {
+			t.Errorf("%s should classify as terminal failure", s)
+		}
+	}
+	for _, s := range pending {
+		if isTerminalFailure(s) || isTerminalSuccess(s) {
+			t.Errorf("%s should classify as still in progress", s)
+		}
+	}
+}
+
+// --- outputs ---------------------------------------------------------------
+
+func TestPrintStackOutputs(t *testing.T) {
+	c := &fakeCFN{describeQueue: []describeResult{{out: stackOutput(
+		cftypes.StackStatusCreateComplete, "",
+		cftypes.Output{OutputKey: aws.String("ApiUrl"), OutputValue: aws.String("https://api.example.com")},
+		cftypes.Output{OutputKey: aws.String("CloudFrontUrl"), OutputValue: aws.String("https://cdn.example.com")},
+		cftypes.Output{OutputKey: aws.String("Other"), OutputValue: aws.String("value")},
+	)}}}
+	d, out := newTestDeployer(&fakeECR{}, c, (&recordingDocker{}).run)
+
+	if err := d.printStackOutputs(context.Background(), "eagle-image-api-dev"); err != nil {
+		t.Fatalf("printStackOutputs() error: %v", err)
+	}
+
+	s := out.String()
+	for _, want := range []string{
+		"=== Deployment Outputs ===",
+		"Other: value",
+		"API Gateway URL: https://api.example.com",
+		"CloudFront URL:  https://cdn.example.com",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("output missing %q, got %q", want, s)
+		}
+	}
+}
+
+func TestPrintStackOutputsErrors(t *testing.T) {
+	t.Run("describe fails", func(t *testing.T) {
+		c := &fakeCFN{describeQueue: []describeResult{{err: errors.New("boom")}}}
+		d, _ := newTestDeployer(&fakeECR{}, c, (&recordingDocker{}).run)
+		if err := d.printStackOutputs(context.Background(), "s"); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+
+	t.Run("no stacks", func(t *testing.T) {
+		c := &fakeCFN{describeQueue: []describeResult{{out: &cloudformation.DescribeStacksOutput{}}}}
+		d, _ := newTestDeployer(&fakeECR{}, c, (&recordingDocker{}).run)
+		if err := d.printStackOutputs(context.Background(), "s"); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+}
+
+// --- end to end (fakes) ----------------------------------------------------
+
+func TestDeployerRunHappyPath(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), "template.yml")
+	if err := os.WriteFile(templatePath, []byte("Resources: {}"), 0o600); err != nil {
+		t.Fatalf("writing template: %v", err)
+	}
+
+	e := &fakeECR{
+		describeOut: &ecr.DescribeRepositoriesOutput{
+			Repositories: []ecrtypes.Repository{{RepositoryUri: aws.String("123.dkr.ecr.us-west-1.amazonaws.com/eagle-image-api")}},
+		},
+		authOut: &ecr.GetAuthorizationTokenOutput{
+			AuthorizationData: []ecrtypes.AuthorizationData{{
+				AuthorizationToken: aws.String(base64.StdEncoding.EncodeToString([]byte("AWS:pw"))),
+				ProxyEndpoint:      aws.String("https://123.dkr.ecr.us-west-1.amazonaws.com"),
+			}},
+		},
+	}
+	c := &fakeCFN{describeQueue: []describeResult{
+		{err: errors.New("missing")}, // existence probe
+		{out: stackOutput(cftypes.StackStatusCreateComplete, "", // wait + outputs
+			cftypes.Output{OutputKey: aws.String("ApiUrl"), OutputValue: aws.String("https://api.example.com")},
+		)},
+	}}
+
+	d, out := newTestDeployer(e, c, (&recordingDocker{}).run)
+	d.flags.template = templatePath
+
+	if err := d.run(context.Background()); err != nil {
+		t.Fatalf("run() error: %v", err)
+	}
+	if !c.created {
+		t.Error("expected the stack to be created")
+	}
+	if !strings.Contains(out.String(), "API Gateway URL: https://api.example.com") {
+		t.Errorf("expected the API URL in the summary, got %q", out.String())
+	}
+}
+
+func TestDeployerRunTemplateFailure(t *testing.T) {
+	d, _ := newTestDeployer(&fakeECR{}, &fakeCFN{}, (&recordingDocker{}).run)
+	d.flags.template = filepath.Join(t.TempDir(), "missing.yml")
+
+	err := d.run(context.Background())
+	if err == nil {
+		t.Fatal("expected an error for a missing template")
+	}
+	if !strings.Contains(err.Error(), "getting template") {
+		t.Errorf("error = %v, want it to identify the template step", err)
+	}
+}
+
+func TestDeployerRunECRFailure(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), "template.yml")
+	if err := os.WriteFile(templatePath, []byte("Resources: {}"), 0o600); err != nil {
+		t.Fatalf("writing template: %v", err)
+	}
+
+	e := &fakeECR{describeErr: errors.New("nope"), createErr: errors.New("denied")}
+	d, _ := newTestDeployer(e, &fakeCFN{}, (&recordingDocker{}).run)
+	d.flags.template = templatePath
+
+	err := d.run(context.Background())
+	if err == nil {
+		t.Fatal("expected an error when ECR setup fails")
+	}
+	if !strings.Contains(err.Error(), "setting up ECR image") {
+		t.Errorf("error = %v, want it to identify the ECR step", err)
+	}
+}
+
+func TestDeployerRunStackFailure(t *testing.T) {
+	templatePath := filepath.Join(t.TempDir(), "template.yml")
+	if err := os.WriteFile(templatePath, []byte("Resources: {}"), 0o600); err != nil {
+		t.Fatalf("writing template: %v", err)
+	}
+
+	e := &fakeECR{
+		describeOut: &ecr.DescribeRepositoriesOutput{
+			Repositories: []ecrtypes.Repository{{RepositoryUri: aws.String("repo")}},
+		},
+		authOut: &ecr.GetAuthorizationTokenOutput{
+			AuthorizationData: []ecrtypes.AuthorizationData{{
+				AuthorizationToken: aws.String(base64.StdEncoding.EncodeToString([]byte("AWS:pw"))),
+				ProxyEndpoint:      aws.String("endpoint"),
+			}},
+		},
+	}
+	c := &fakeCFN{
+		describeQueue: []describeResult{{err: errors.New("missing")}},
+		createErr:     errors.New("LimitExceeded"),
+	}
+	d, _ := newTestDeployer(e, c, (&recordingDocker{}).run)
+	d.flags.template = templatePath
+
+	err := d.run(context.Background())
+	if err == nil {
+		t.Fatal("expected an error when the stack deployment fails")
+	}
+	if !strings.Contains(err.Error(), "deploying stack") {
+		t.Errorf("error = %v, want it to identify the stack step", err)
+	}
+}
+
+// TestRunDockerCmdReportsMissingBinary exercises the real runner without
+// depending on docker being installed: an argument list this bogus fails
+// either way, and the point is that the error is surfaced rather than
+// swallowed.
+func TestRunDockerCmdReportsFailure(t *testing.T) {
+	if err := runDockerCmd("", "--definitely-not-a-docker-flag"); err == nil {
+		t.Skip("docker accepted an invalid flag; nothing to assert")
+	}
 }

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -1,0 +1,57 @@
+// Package commands implements the subcommands of the `eagle` CLI, which
+// deploys the Eagle Image API into a user's own AWS account.
+//
+// The AWS calls are reached through narrow interfaces ([ecrAPI], [cfnAPI])
+// rather than the concrete SDK clients so the deployment logic can be
+// exercised without credentials.
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Build metadata, overridden at release time via -ldflags -X.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+// SetBuildInfo overrides the version metadata reported by `eagle --version`.
+// It exists for embedders and tests; releases inject the values with -ldflags.
+func SetBuildInfo(v, c, d string) {
+	version, commit, date = v, c, d
+}
+
+// VersionString renders the version line shown by `eagle --version`.
+func VersionString() string {
+	return fmt.Sprintf("eagle %s (commit: %s, built: %s)", version, commit, date)
+}
+
+// NewRootCmd builds the `eagle` root command with all subcommands attached.
+// A fresh command is constructed on each call so tests are independent.
+func NewRootCmd() *cobra.Command {
+	var showVersion bool
+
+	root := &cobra.Command{
+		Use:           "eagle",
+		Short:         "Eagle - Image Optimization API CLI",
+		Long:          "Eagle CLI allows you to deploy the Eagle Image Optimization API to AWS with a single command.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if showVersion {
+				fmt.Fprintln(cmd.OutOrStdout(), VersionString())
+				return nil
+			}
+			return cmd.Help()
+		},
+	}
+
+	root.Flags().BoolVarP(&showVersion, "version", "v", false, "Show version, commit, and build date")
+	root.AddCommand(DeployCmd)
+
+	return root
+}

--- a/internal/commands/root_test.go
+++ b/internal/commands/root_test.go
@@ -1,0 +1,140 @@
+package commands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// swapTemplateURL points the template fetch at url for the duration of a test
+// and returns a function that restores the original value.
+func swapTemplateURL(t *testing.T, url string) func() {
+	t.Helper()
+	original := templateURL
+	templateURL = url
+	return func() { templateURL = original }
+}
+
+// newDeployCmdForTest builds a deploy command with its own flag storage, so a
+// test can set flags without mutating the package-level command.
+func newDeployCmdForTest() (*cobra.Command, *deployFlags) {
+	dst := &deployFlags{}
+	cmd := &cobra.Command{Use: "deploy"}
+	registerDeployFlags(cmd, dst)
+	return cmd, dst
+}
+
+func TestNewRootCmdMetadata(t *testing.T) {
+	root := NewRootCmd()
+
+	if root.Use != "eagle" {
+		t.Errorf("Use = %q, want eagle", root.Use)
+	}
+	if root.Short == "" {
+		t.Error("Short description should not be empty")
+	}
+	if root.Flags().Lookup("version") == nil {
+		t.Error("expected a --version flag")
+	}
+	if s := root.Flags().ShorthandLookup("v"); s == nil {
+		t.Error("expected a -v shorthand for --version")
+	}
+}
+
+func TestNewRootCmdHasDeploySubcommand(t *testing.T) {
+	root := NewRootCmd()
+
+	var found bool
+	for _, c := range root.Commands() {
+		if c.Name() == "deploy" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected a deploy subcommand")
+	}
+}
+
+func TestNewRootCmdReturnsFreshCommands(t *testing.T) {
+	// Each call must produce an independent command; sharing the --version
+	// flag storage between invocations would leak state across runs.
+	first := NewRootCmd()
+	second := NewRootCmd()
+
+	if first == second {
+		t.Fatal("NewRootCmd() returned the same instance twice")
+	}
+	if err := first.Flags().Set("version", "true"); err != nil {
+		t.Fatalf("setting version on the first command: %v", err)
+	}
+	if second.Flags().Lookup("version").Value.String() != "false" {
+		t.Error("setting --version on one command changed another")
+	}
+}
+
+func TestRootCmdVersionFlag(t *testing.T) {
+	SetBuildInfo("1.2.3", "abc1234", "2026-01-01")
+	t.Cleanup(func() { SetBuildInfo("dev", "none", "unknown") })
+
+	var out bytes.Buffer
+	root := NewRootCmd()
+	root.SetOut(&out)
+	root.SetArgs([]string{"--version"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	s := out.String()
+	for _, want := range []string{"eagle 1.2.3", "abc1234", "2026-01-01"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("version output missing %q, got %q", want, s)
+		}
+	}
+}
+
+func TestRootCmdWithoutArgsPrintsHelp(t *testing.T) {
+	var out bytes.Buffer
+	root := NewRootCmd()
+	root.SetOut(&out)
+	root.SetArgs([]string{})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	s := out.String()
+	if !strings.Contains(s, "Usage:") {
+		t.Errorf("expected help output, got %q", s)
+	}
+	if !strings.Contains(s, "deploy") {
+		t.Errorf("expected help to list the deploy command, got %q", s)
+	}
+}
+
+func TestVersionStringDefaults(t *testing.T) {
+	SetBuildInfo("dev", "none", "unknown")
+
+	got := VersionString()
+	if !strings.HasPrefix(got, "eagle dev") {
+		t.Errorf("VersionString() = %q, want it to start with %q", got, "eagle dev")
+	}
+	for _, want := range []string{"commit: none", "built: unknown"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("VersionString() = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
+func TestSetBuildInfo(t *testing.T) {
+	t.Cleanup(func() { SetBuildInfo("dev", "none", "unknown") })
+
+	SetBuildInfo("v9.9.9", "deadbeef", "2026-08-08")
+
+	if got := VersionString(); got != "eagle v9.9.9 (commit: deadbeef, built: 2026-08-08)" {
+		t.Errorf("VersionString() = %q", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,9 @@
+// Package config loads the Eagle Image API runtime settings from environment
+// variables.
+//
+// Every setting has a default, so the service starts with no environment set
+// at all. Values that fail to parse fall back to their default rather than
+// aborting startup: a malformed QUALITY should not take the service down.
 package config
 
 import (
@@ -6,29 +12,52 @@ import (
 	"strings"
 )
 
-// Config holds all application configuration loaded from environment variables.
+// Config holds all application configuration loaded from environment
+// variables. See [FromEnv] for the variable names and defaults.
 type Config struct {
-	Environment     string
-	APIEndpoint     string
-	Port            int
-	Quality         int
-	Fit             string
-	LogLevel        string
+	// Environment names the deployment, e.g. "production" or "development".
+	Environment string
+	// APIEndpoint is the request path that serves image transformations.
+	APIEndpoint string
+	// Port is the TCP port used when running outside AWS Lambda.
+	Port int
+	// Quality is the default output quality, 0-100, for lossy encoders.
+	Quality int
+	// Fit is the default resize mode when a request omits the fit parameter.
+	Fit string
+	// LogLevel is the verbosity passed to the logger package.
+	LogLevel string
+	// OriginWhitelist is the raw comma-separated allowlist, or "*" for any.
 	OriginWhitelist string
+	// AllowAllOrigins reports whether OriginWhitelist was "*".
 	AllowAllOrigins bool
-	Origins         []string
+	// Origins holds the parsed, trimmed allowlist. Empty when AllowAllOrigins.
+	Origins []string
+	// RedirectOnError sends a 302 to the source image instead of an error.
 	RedirectOnError bool
-	WebP            bool
-	AVIF            bool
-	AVIFMaxMP       float64
+	// WebP enables WebP output for clients that accept it.
+	WebP bool
+	// AVIF enables AVIF output for clients that accept it.
+	AVIF bool
+	// AVIFMaxMP caps the megapixel area eligible for AVIF encoding, which is
+	// slow enough on large images to risk a Lambda timeout.
+	AVIFMaxMP float64
 }
 
-// Cfg is the global configuration instance.
+// Cfg is the global configuration instance populated by [Load].
 var Cfg Config
 
-// Load reads environment variables and populates the global Config.
-func Load() {
-	Cfg = Config{
+// FromEnv builds a Config from the process environment.
+//
+// The variables read, with their defaults, are: ENVIRONMENT (production),
+// API_ENDPOINT (/api/v1/image), PORT (3000), QUALITY (80), FIT (outside),
+// LOG_LEVEL (silly), ORIGIN_WHITELIST (*), REDIRECT_ON_ERROR (false),
+// WEBP (true), AVIF (true), and AVIF_MAX_MP (2).
+//
+// ORIGIN_WHITELIST accepts "*" to allow every origin, or a comma-separated
+// list of hostnames; surrounding whitespace on each entry is trimmed.
+func FromEnv() Config {
+	c := Config{
 		Environment:     envOrDefault("ENVIRONMENT", "production"),
 		APIEndpoint:     envOrDefault("API_ENDPOINT", "/api/v1/image"),
 		Port:            envOrDefaultInt("PORT", 3000),
@@ -42,14 +71,21 @@ func Load() {
 		AVIFMaxMP:       envOrDefaultFloat("AVIF_MAX_MP", 2),
 	}
 
-	if Cfg.OriginWhitelist == "*" {
-		Cfg.AllowAllOrigins = true
+	if c.OriginWhitelist == "*" {
+		c.AllowAllOrigins = true
 	} else {
-		Cfg.Origins = strings.Split(Cfg.OriginWhitelist, ",")
-		for i := range Cfg.Origins {
-			Cfg.Origins[i] = strings.TrimSpace(Cfg.Origins[i])
+		c.Origins = strings.Split(c.OriginWhitelist, ",")
+		for i := range c.Origins {
+			c.Origins[i] = strings.TrimSpace(c.Origins[i])
 		}
 	}
+
+	return c
+}
+
+// Load reads the environment and stores the result in the global [Cfg].
+func Load() {
+	Cfg = FromEnv()
 }
 
 func envOrDefault(key, fallback string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,183 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFromEnvDefaults(t *testing.T) {
+	// t.Setenv on every key with an empty value guarantees a clean slate
+	// regardless of what the developer has exported locally.
+	for _, k := range []string{
+		"ENVIRONMENT", "API_ENDPOINT", "PORT", "QUALITY", "FIT", "LOG_LEVEL",
+		"ORIGIN_WHITELIST", "REDIRECT_ON_ERROR", "WEBP", "AVIF", "AVIF_MAX_MP",
+	} {
+		t.Setenv(k, "")
+	}
+
+	c := FromEnv()
+
+	want := Config{
+		Environment:     "production",
+		APIEndpoint:     "/api/v1/image",
+		Port:            3000,
+		Quality:         80,
+		Fit:             "outside",
+		LogLevel:        "silly",
+		OriginWhitelist: "*",
+		AllowAllOrigins: true,
+		RedirectOnError: false,
+		WebP:            true,
+		AVIF:            true,
+		AVIFMaxMP:       2,
+	}
+
+	if !reflect.DeepEqual(c, want) {
+		t.Errorf("FromEnv() = %+v, want %+v", c, want)
+	}
+}
+
+func TestFromEnvOverrides(t *testing.T) {
+	t.Setenv("ENVIRONMENT", "development")
+	t.Setenv("API_ENDPOINT", "/img")
+	t.Setenv("PORT", "8080")
+	t.Setenv("QUALITY", "55")
+	t.Setenv("FIT", "cover")
+	t.Setenv("LOG_LEVEL", "error")
+	t.Setenv("ORIGIN_WHITELIST", "example.com, cdn.example.com ,foo.test")
+	t.Setenv("REDIRECT_ON_ERROR", "true")
+	t.Setenv("WEBP", "false")
+	t.Setenv("AVIF", "no")
+	t.Setenv("AVIF_MAX_MP", "4.5")
+
+	c := FromEnv()
+
+	if c.Environment != "development" {
+		t.Errorf("Environment = %q, want development", c.Environment)
+	}
+	if c.APIEndpoint != "/img" {
+		t.Errorf("APIEndpoint = %q, want /img", c.APIEndpoint)
+	}
+	if c.Port != 8080 {
+		t.Errorf("Port = %d, want 8080", c.Port)
+	}
+	if c.Quality != 55 {
+		t.Errorf("Quality = %d, want 55", c.Quality)
+	}
+	if c.Fit != "cover" {
+		t.Errorf("Fit = %q, want cover", c.Fit)
+	}
+	if c.LogLevel != "error" {
+		t.Errorf("LogLevel = %q, want error", c.LogLevel)
+	}
+	if !c.RedirectOnError {
+		t.Error("RedirectOnError = false, want true")
+	}
+	if c.WebP {
+		t.Error("WebP = true, want false")
+	}
+	if c.AVIF {
+		t.Error(`AVIF = true, want false for "no"`)
+	}
+	if c.AVIFMaxMP != 4.5 {
+		t.Errorf("AVIFMaxMP = %v, want 4.5", c.AVIFMaxMP)
+	}
+	if c.AllowAllOrigins {
+		t.Error("AllowAllOrigins = true, want false for an explicit list")
+	}
+	wantOrigins := []string{"example.com", "cdn.example.com", "foo.test"}
+	if !reflect.DeepEqual(c.Origins, wantOrigins) {
+		t.Errorf("Origins = %q, want %q", c.Origins, wantOrigins)
+	}
+}
+
+func TestFromEnvSingleOrigin(t *testing.T) {
+	t.Setenv("ORIGIN_WHITELIST", "only.example.com")
+
+	c := FromEnv()
+
+	if c.AllowAllOrigins {
+		t.Error("AllowAllOrigins = true, want false")
+	}
+	if !reflect.DeepEqual(c.Origins, []string{"only.example.com"}) {
+		t.Errorf("Origins = %q, want [only.example.com]", c.Origins)
+	}
+}
+
+func TestFromEnvMalformedValuesFallBackToDefaults(t *testing.T) {
+	t.Setenv("PORT", "not-a-number")
+	t.Setenv("QUALITY", "12.5") // Atoi rejects floats
+	t.Setenv("AVIF_MAX_MP", "huge")
+
+	c := FromEnv()
+
+	if c.Port != 3000 {
+		t.Errorf("Port = %d, want default 3000 for malformed input", c.Port)
+	}
+	if c.Quality != 80 {
+		t.Errorf("Quality = %d, want default 80 for malformed input", c.Quality)
+	}
+	if c.AVIFMaxMP != 2 {
+		t.Errorf("AVIFMaxMP = %v, want default 2 for malformed input", c.AVIFMaxMP)
+	}
+}
+
+func TestBoolParsing(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"true", true},
+		{"TRUE", true},
+		{"True", true},
+		{"1", true},
+		{"yes", true},
+		{"YES", true},
+		{"false", false},
+		{"0", false},
+		{"no", false},
+		{"maybe", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Setenv("REDIRECT_ON_ERROR", tt.value)
+			if got := FromEnv().RedirectOnError; got != tt.want {
+				t.Errorf("REDIRECT_ON_ERROR=%q gave %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBoolUnsetKeepsFallback(t *testing.T) {
+	// WEBP defaults to true and REDIRECT_ON_ERROR to false; an unset variable
+	// must preserve each distinct fallback rather than coercing to false.
+	t.Setenv("WEBP", "")
+	t.Setenv("REDIRECT_ON_ERROR", "")
+
+	c := FromEnv()
+
+	if !c.WebP {
+		t.Error("WebP = false, want default true when unset")
+	}
+	if c.RedirectOnError {
+		t.Error("RedirectOnError = true, want default false when unset")
+	}
+}
+
+func TestLoadPopulatesGlobal(t *testing.T) {
+	t.Setenv("ENVIRONMENT", "staging")
+	t.Setenv("QUALITY", "42")
+
+	original := Cfg
+	t.Cleanup(func() { Cfg = original })
+
+	Load()
+
+	if Cfg.Environment != "staging" {
+		t.Errorf("Cfg.Environment = %q, want staging", Cfg.Environment)
+	}
+	if Cfg.Quality != 42 {
+		t.Errorf("Cfg.Quality = %d, want 42", Cfg.Quality)
+	}
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -1,71 +1,69 @@
+// Package handler routes API Gateway requests to the image pipeline.
+//
+// Three paths are served: /health for liveness checks, the configured
+// [config.Config.APIEndpoint] for transformations, and everything else as a
+// 404. Errors are reported as 400 responses, or as a 302 redirect back to the
+// source image when REDIRECT_ON_ERROR is enabled, so a broken transformation
+// degrades to the original asset instead of a broken image on the page.
 package handler
 
 import (
 	"context"
+	"net/http"
 	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
-	"github.com/zantez/image-api/internal/config"
-	"github.com/zantez/image-api/internal/image"
-	"github.com/zantez/image-api/internal/logger"
+	"github.com/nicobistolfi/eagle-image-api/internal/config"
+	"github.com/nicobistolfi/eagle-image-api/internal/image"
+	"github.com/nicobistolfi/eagle-image-api/internal/logger"
 )
 
-// Handle is the AWS Lambda handler function.
-func Handle(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+// Handle is the AWS Lambda entry point. It accepts API Gateway proxy events
+// and always returns a response with a nil error: failures are communicated
+// through the HTTP status code so API Gateway does not surface a 502.
+func Handle(_ context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	logger.Debug("request", "method", event.HTTPMethod, "path", event.Path)
 
-	switch event.HTTPMethod {
-	case "GET":
-		return handleGet(event)
-	default:
-		return events.APIGatewayProxyResponse{
-			StatusCode: 405,
-			Body:       "Method Not Allowed",
-		}, nil
+	if event.HTTPMethod != http.MethodGet {
+		return textResponse(http.StatusMethodNotAllowed, "Method Not Allowed"), nil
 	}
+
+	return handleGet(event), nil
 }
 
-func handleGet(event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+// handleGet dispatches a GET by path.
+func handleGet(event events.APIGatewayProxyRequest) events.APIGatewayProxyResponse {
 	switch event.Path {
 	case "/health":
 		logger.Debug("health endpoint")
-		return events.APIGatewayProxyResponse{
-			StatusCode: 200,
-			Body:       "\U0001F985", // 🦅
-		}, nil
+		return textResponse(http.StatusOK, "\U0001F985") // 🦅
 	case config.Cfg.APIEndpoint:
 		logger.Debug("api endpoint")
 		return processImage(event)
 	default:
 		logger.Debug("unknown endpoint", "path", event.Path)
-		return events.APIGatewayProxyResponse{
-			StatusCode: 404,
-			Body:       "Not Found",
-		}, nil
+		return textResponse(http.StatusNotFound, "Not Found")
 	}
 }
 
-func processImage(event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+// processImage fetches, transforms, and encodes the requested image.
+func processImage(event events.APIGatewayProxyRequest) events.APIGatewayProxyResponse {
 	imageURL := event.QueryStringParameters["url"]
 	if imageURL == "" {
-		return events.APIGatewayProxyResponse{
-			StatusCode: 400,
-			Body:       "Missing required parameter: url",
-		}, nil
+		return textResponse(http.StatusBadRequest, "Missing required parameter: url")
 	}
 
 	img := image.New(imageURL)
 
+	// A HEAD request first avoids downloading a whole HTML error page when
+	// the URL does not actually point at an image.
 	isImg, err := img.IsImage()
 	if err != nil {
 		return handleError(event, err)
 	}
 	if !isImg {
 		logger.Debug("HEAD check: not an image", "url", imageURL)
-		return events.APIGatewayProxyResponse{
-			StatusCode: 404,
-			Body:       "Not Found",
-		}, nil
+		return textResponse(http.StatusNotFound, "Not Found")
 	}
 
 	if err := img.Load(); err != nil {
@@ -73,47 +71,48 @@ func processImage(event events.APIGatewayProxyRequest) (events.APIGatewayProxyRe
 	}
 
 	params := image.ParseQueryParams(event.QueryStringParameters)
-	acceptHeader := findAcceptHeader(event.Headers)
-
-	if err := img.Process(params, acceptHeader); err != nil {
+	if err := img.Process(params, findAcceptHeader(event.Headers)); err != nil {
 		return handleError(event, err)
 	}
 
-	headers := img.ResponseHeaders()
 	return events.APIGatewayProxyResponse{
-		StatusCode:      200,
-		Headers:         headers,
+		StatusCode:      http.StatusOK,
+		Headers:         img.ResponseHeaders(),
 		Body:            img.Base64(),
 		IsBase64Encoded: true,
-	}, nil
+	}
 }
 
+// findAcceptHeader returns the Accept header value regardless of the casing
+// API Gateway happens to deliver.
 func findAcceptHeader(headers map[string]string) string {
 	for k, v := range headers {
-		if strings.ToLower(k) == "accept" {
+		if strings.EqualFold(k, "accept") {
 			return v
 		}
 	}
 	return ""
 }
 
-func handleError(event events.APIGatewayProxyRequest, err error) (events.APIGatewayProxyResponse, error) {
+// handleError turns a processing failure into a response: a 400 by default,
+// or a redirect to the source image when RedirectOnError is enabled.
+func handleError(event events.APIGatewayProxyRequest, err error) events.APIGatewayProxyResponse {
 	logger.Error("request failed", "path", event.Path, "error", err.Error())
 
 	if config.Cfg.RedirectOnError {
 		if url := event.QueryStringParameters["url"]; url != "" {
 			logger.Error("redirecting to original", "url", url)
 			return events.APIGatewayProxyResponse{
-				StatusCode: 302,
-				Headers: map[string]string{
-					"Location": url,
-				},
-			}, nil
+				StatusCode: http.StatusFound,
+				Headers:    map[string]string{"Location": url},
+			}
 		}
 	}
 
-	return events.APIGatewayProxyResponse{
-		StatusCode: 400,
-		Body:       err.Error(),
-	}, nil
+	return textResponse(http.StatusBadRequest, err.Error())
+}
+
+// textResponse builds a plain response carrying only a status and body.
+func textResponse(status int, body string) events.APIGatewayProxyResponse {
+	return events.APIGatewayProxyResponse{StatusCode: status, Body: body}
 }

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -1,0 +1,407 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	stdimage "image"
+	"image/color"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/davidbyttow/govips/v2/vips"
+	"github.com/nicobistolfi/eagle-image-api/internal/config"
+)
+
+// testPNG encodes a small gradient PNG. Generating it rather than embedding a
+// blob keeps the fixture readable and guarantees libvips gets real pixel data.
+func testPNG(t *testing.T) []byte {
+	t.Helper()
+
+	const size = 32
+	img := stdimage.NewRGBA(stdimage.Rect(0, 0, size, size))
+	for y := 0; y < size; y++ {
+		for x := 0; x < size; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x * 8), G: uint8(y * 8), B: 128, A: 255})
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encoding test PNG: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestMain(m *testing.M) {
+	vips.LoggingSettings(nil, vips.LogLevelError)
+	if err := vips.Startup(nil); err != nil {
+		panic("starting vips: " + err.Error())
+	}
+	code := m.Run()
+	vips.Shutdown()
+	os.Exit(code)
+}
+
+// setConfig installs a test configuration and restores the previous one.
+func setConfig(t *testing.T, c config.Config) {
+	t.Helper()
+	original := config.Cfg
+	config.Cfg = c
+	t.Cleanup(func() { config.Cfg = original })
+}
+
+func defaultTestConfig() config.Config {
+	return config.Config{
+		Environment:     "test",
+		APIEndpoint:     "/api/v1/image",
+		Quality:         80,
+		Fit:             "outside",
+		LogLevel:        "error",
+		OriginWhitelist: "*",
+		AllowAllOrigins: true,
+		WebP:            true,
+		AVIF:            true,
+		AVIFMaxMP:       2,
+	}
+}
+
+// imageServer serves the test PNG with the given content type.
+func imageServer(t *testing.T, contentType string) *httptest.Server {
+	t.Helper()
+	png := testPNG(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", contentType)
+		_, _ = w.Write(png)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestHandleRejectsNonGET(t *testing.T) {
+	setConfig(t, defaultTestConfig())
+
+	for _, method := range []string{"POST", "PUT", "DELETE", "PATCH"} {
+		t.Run(method, func(t *testing.T) {
+			resp, err := Handle(context.Background(), events.APIGatewayProxyRequest{
+				HTTPMethod: method,
+				Path:       "/api/v1/image",
+			})
+			if err != nil {
+				t.Fatalf("Handle() error: %v", err)
+			}
+			if resp.StatusCode != http.StatusMethodNotAllowed {
+				t.Errorf("status = %d, want 405", resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestHandleHealth(t *testing.T) {
+	setConfig(t, defaultTestConfig())
+
+	resp, err := Handle(context.Background(), events.APIGatewayProxyRequest{
+		HTTPMethod: "GET",
+		Path:       "/health",
+	})
+	if err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if resp.Body != "\U0001F985" {
+		t.Errorf("body = %q, want the eagle emoji", resp.Body)
+	}
+}
+
+func TestHandleUnknownPath(t *testing.T) {
+	setConfig(t, defaultTestConfig())
+
+	resp, err := Handle(context.Background(), events.APIGatewayProxyRequest{
+		HTTPMethod: "GET",
+		Path:       "/nope",
+	})
+	if err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// TestHandleHonoursConfiguredEndpoint verifies the route follows
+// API_ENDPOINT rather than a hardcoded path.
+func TestHandleHonoursConfiguredEndpoint(t *testing.T) {
+	c := defaultTestConfig()
+	c.APIEndpoint = "/custom/img"
+	setConfig(t, c)
+
+	srv := imageServer(t, "image/png")
+
+	resp, err := Handle(context.Background(), events.APIGatewayProxyRequest{
+		HTTPMethod:            "GET",
+		Path:                  "/custom/img",
+		QueryStringParameters: map[string]string{"url": srv.URL + "/a.png"},
+	})
+	if err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 (body: %s)", resp.StatusCode, resp.Body)
+	}
+
+	// The old default path must now 404.
+	resp, err = Handle(context.Background(), events.APIGatewayProxyRequest{
+		HTTPMethod: "GET",
+		Path:       "/api/v1/image",
+	})
+	if err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 for the unconfigured path", resp.StatusCode)
+	}
+}
+
+func TestProcessImageMissingURL(t *testing.T) {
+	setConfig(t, defaultTestConfig())
+
+	resp, err := Handle(context.Background(), events.APIGatewayProxyRequest{
+		HTTPMethod:            "GET",
+		Path:                  "/api/v1/image",
+		QueryStringParameters: map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+	if !strings.Contains(resp.Body, "url") {
+		t.Errorf("body = %q, want it to name the missing parameter", resp.Body)
+	}
+}
+
+func TestProcessImageSuccess(t *testing.T) {
+	setConfig(t, defaultTestConfig())
+	srv := imageServer(t, "image/png")
+
+	resp, err := Handle(context.Background(), events.APIGatewayProxyRequest{
+		HTTPMethod:            "GET",
+		Path:                  "/api/v1/image",
+		QueryStringParameters: map[string]string{"url": srv.URL + "/a.png"},
+	})
+	if err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", resp.StatusCode, resp.Body)
+	}
+	if !resp.IsBase64Encoded {
+		t.Error("IsBase64Encoded = false, want true")
+	}
+	if _, err := base64.StdEncoding.DecodeString(resp.Body); err != nil {
+		t.Errorf("body is not valid base64: %v", err)
+	}
+	if resp.Headers["Content-Type"] == "" {
+		t.Error("expected a Content-Type header")
+	}
+	if resp.Headers["Cache-Control"] == "" {
+		t.Error("expected a Cache-Control header")
+	}
+}
+
+// TestProcessImageNegotiatesWebP checks the Accept header is honoured and
+// that the lookup is case-insensitive, since API Gateway does not normalise
+// header casing.
+func TestProcessImageNegotiatesWebP(t *testing.T) {
+	setConfig(t, defaultTestConfig())
+	srv := imageServer(t, "image/png")
+
+	for _, headerName := range []string{"Accept", "accept", "ACCEPT"} {
+		t.Run(headerName, func(t *testing.T) {
+			resp, err := Handle(context.Background(), events.APIGatewayProxyRequest{
+				HTTPMethod:            "GET",
+				Path:                  "/api/v1/image",
+				Headers:               map[string]string{headerName: "image/webp,*/*"},
+				QueryStringParameters: map[string]string{"url": srv.URL + "/a.png"},
+			})
+			if err != nil {
+				t.Fatalf("Handle() error: %v", err)
+			}
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200 (body: %s)", resp.StatusCode, resp.Body)
+			}
+			if resp.Headers["Content-Type"] != "image/webp" {
+				t.Errorf("Content-Type = %q, want image/webp", resp.Headers["Content-Type"])
+			}
+		})
+	}
+}
+
+func TestProcessImageNonImageURL(t *testing.T) {
+	setConfig(t, defaultTestConfig())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html></html>"))
+	}))
+	defer srv.Close()
+
+	resp, err := Handle(context.Background(), events.APIGatewayProxyRequest{
+		HTTPMethod:            "GET",
+		Path:                  "/api/v1/image",
+		QueryStringParameters: map[string]string{"url": srv.URL + "/page.html"},
+	})
+	if err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 for a non-image URL", resp.StatusCode)
+	}
+}
+
+func TestProcessImageUnreachableURL(t *testing.T) {
+	setConfig(t, defaultTestConfig())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL + "/gone.png"
+	srv.Close()
+
+	resp, err := Handle(context.Background(), events.APIGatewayProxyRequest{
+		HTTPMethod:            "GET",
+		Path:                  "/api/v1/image",
+		QueryStringParameters: map[string]string{"url": url},
+	})
+	if err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestProcessImageOriginNotAllowed(t *testing.T) {
+	c := defaultTestConfig()
+	c.AllowAllOrigins = false
+	c.OriginWhitelist = "allowed.example.com"
+	c.Origins = []string{"allowed.example.com"}
+	setConfig(t, c)
+
+	srv := imageServer(t, "image/png")
+
+	resp, err := Handle(context.Background(), events.APIGatewayProxyRequest{
+		HTTPMethod:            "GET",
+		Path:                  "/api/v1/image",
+		QueryStringParameters: map[string]string{"url": srv.URL + "/a.png"},
+	})
+	if err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for a disallowed origin", resp.StatusCode)
+	}
+	if !strings.Contains(resp.Body, "Origin not allowed") {
+		t.Errorf("body = %q, want the origin rejection message", resp.Body)
+	}
+}
+
+func TestProcessImageCorruptImageData(t *testing.T) {
+	setConfig(t, defaultTestConfig())
+
+	// Claims to be an image but is not decodable, so the failure happens
+	// inside libvips rather than at fetch time.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("definitely not a png"))
+	}))
+	defer srv.Close()
+
+	resp, err := Handle(context.Background(), events.APIGatewayProxyRequest{
+		HTTPMethod:            "GET",
+		Path:                  "/api/v1/image",
+		QueryStringParameters: map[string]string{"url": srv.URL + "/broken.png"},
+	})
+	if err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for undecodable image data", resp.StatusCode)
+	}
+}
+
+func TestRedirectOnError(t *testing.T) {
+	c := defaultTestConfig()
+	c.RedirectOnError = true
+	setConfig(t, c)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("not a real png"))
+	}))
+	defer srv.Close()
+
+	source := srv.URL + "/broken.png"
+	resp, err := Handle(context.Background(), events.APIGatewayProxyRequest{
+		HTTPMethod:            "GET",
+		Path:                  "/api/v1/image",
+		QueryStringParameters: map[string]string{"url": source},
+	})
+	if err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status = %d, want 302", resp.StatusCode)
+	}
+	if resp.Headers["Location"] != source {
+		t.Errorf("Location = %q, want %q", resp.Headers["Location"], source)
+	}
+}
+
+// TestRedirectOnErrorWithoutURL covers the case where redirect is enabled but
+// there is no source URL to redirect to; a 400 is the only sensible answer.
+func TestRedirectOnErrorWithoutURL(t *testing.T) {
+	c := defaultTestConfig()
+	c.RedirectOnError = true
+	setConfig(t, c)
+
+	resp := handleError(events.APIGatewayProxyRequest{
+		QueryStringParameters: map[string]string{},
+	}, errAny{})
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 when there is no URL to redirect to", resp.StatusCode)
+	}
+}
+
+type errAny struct{}
+
+func (errAny) Error() string { return "synthetic failure" }
+
+func TestFindAcceptHeader(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    string
+	}{
+		{"canonical", map[string]string{"Accept": "image/webp"}, "image/webp"},
+		{"lowercase", map[string]string{"accept": "image/avif"}, "image/avif"},
+		{"mixed case", map[string]string{"AcCePt": "image/png"}, "image/png"},
+		{"absent", map[string]string{"User-Agent": "curl"}, ""},
+		{"nil map", nil, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findAcceptHeader(tt.headers); got != tt.want {
+				t.Errorf("findAcceptHeader(%v) = %q, want %q", tt.headers, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -67,58 +67,63 @@ type QueryParams struct {
 	Kernel       string
 }
 
-// ParseQueryParams converts a map of string parameters to QueryParams.
+// ParseQueryParams converts a map of request parameters to [QueryParams].
+//
+// Malformed numeric values are left at their zero value rather than rejected,
+// so a typo in one parameter degrades that single transformation instead of
+// failing the whole request.
 func ParseQueryParams(m map[string]string) QueryParams {
 	p := QueryParams{
-		URL:        m["url"],
-		Fit:        m["fit"],
-		Position:   m["position"],
-		Background: m["background"],
-		Kernel:     m["kernel"],
+		URL:          m["url"],
+		Fit:          m["fit"],
+		Position:     m["position"],
+		Background:   m["background"],
+		Kernel:       m["kernel"],
+		Width:        intParam(m, "width"),
+		Height:       intParam(m, "height"),
+		Quality:      intParam(m, "quality"),
+		Rotate:       intParam(m, "rotate"),
+		AlphaQuality: intParam(m, "alphaQuality"),
+		Loop:         intParam(m, "loop"),
+		Delay:        intParam(m, "delay"),
+		WebpEffort:   intParam(m, "webpEffort"),
+		Blur:         floatParam(m, "blur"),
+		Sharpen:      floatParam(m, "sharpen"),
+		Lossless:     boolPtrParam(m, "lossless"),
 	}
 
-	if v, ok := m["width"]; ok && v != "" {
-		p.Width, _ = strconv.Atoi(v)
-	}
-	if v, ok := m["height"]; ok && v != "" {
-		p.Height, _ = strconv.Atoi(v)
-	}
-	if v, ok := m["quality"]; ok && v != "" {
-		p.Quality, _ = strconv.Atoi(v)
-	}
-	if v, ok := m["blur"]; ok && v != "" {
-		p.Blur, _ = strconv.ParseFloat(v, 64)
-	}
-	if v, ok := m["sharpen"]; ok && v != "" {
-		p.Sharpen, _ = strconv.ParseFloat(v, 64)
-	}
-	if _, ok := m["flip"]; ok {
-		p.Flip = true
-	}
-	if _, ok := m["flop"]; ok {
-		p.Flop = true
-	}
-	if v, ok := m["rotate"]; ok && v != "" {
-		p.Rotate, _ = strconv.Atoi(v)
-	}
-	if v, ok := m["alphaQuality"]; ok && v != "" {
-		p.AlphaQuality, _ = strconv.Atoi(v)
-	}
-	if v, ok := m["loop"]; ok && v != "" {
-		p.Loop, _ = strconv.Atoi(v)
-	}
-	if v, ok := m["delay"]; ok && v != "" {
-		p.Delay, _ = strconv.Atoi(v)
-	}
-	if v, ok := m["webpEffort"]; ok && v != "" {
-		p.WebpEffort, _ = strconv.Atoi(v)
-	}
-	if v, ok := m["lossless"]; ok {
-		b := strings.ToLower(v) == "true" || v == "1"
-		p.Lossless = &b
-	}
+	// flip and flop are flags: presence alone turns them on, so `?flip` works
+	// as well as `?flip=1`.
+	_, p.Flip = m["flip"]
+	_, p.Flop = m["flop"]
 
 	return p
+}
+
+// intParam reads an integer parameter, returning 0 when it is absent, empty,
+// or unparseable.
+func intParam(m map[string]string, key string) int {
+	n, _ := strconv.Atoi(m[key])
+	return n
+}
+
+// floatParam reads a float parameter, returning 0 when it is absent, empty,
+// or unparseable.
+func floatParam(m map[string]string, key string) float64 {
+	f, _ := strconv.ParseFloat(m[key], 64)
+	return f
+}
+
+// boolPtrParam reads an optional boolean. It returns nil when the parameter is
+// absent, which keeps "not specified" distinct from "explicitly false" so the
+// encoder default is preserved.
+func boolPtrParam(m map[string]string, key string) *bool {
+	v, ok := m[key]
+	if !ok {
+		return nil
+	}
+	b := strings.EqualFold(v, "true") || v == "1"
+	return &b
 }
 
 // Image handles fetching, processing, and converting images.
@@ -213,6 +218,8 @@ func (img *Image) Process(params QueryParams, acceptHeader string) error {
 	return nil
 }
 
+// resize scales the image according to the requested fit mode, then records
+// the resulting dimensions on img.
 func (img *Image) resize(vImg *vips.ImageRef, p QueryParams) error {
 	if p.Width == 0 && p.Height == 0 {
 		return nil
@@ -226,48 +233,47 @@ func (img *Image) resize(vImg *vips.ImageRef, p QueryParams) error {
 		fit = config.Cfg.Fit
 	}
 
-	switch fit {
-	case "cover":
-		// Resize to cover target dimensions, then crop
-		if err := resizeCover(vImg, p.Width, p.Height, p.Position); err != nil {
-			return err
-		}
-	case "contain":
-		// Resize to fit within target, maintaining aspect ratio
-		if err := resizeContain(vImg, p.Width, p.Height); err != nil {
-			return err
-		}
-	case "fill":
-		// Force resize to exact dimensions
-		if p.Width > 0 && p.Height > 0 {
-			hScale := float64(p.Width) / float64(origWidth)
-			vScale := float64(p.Height) / float64(origHeight)
-			if err := vImg.ResizeWithVScale(hScale, vScale, vips.KernelLanczos3); err != nil {
-				return err
-			}
-		}
-	case "inside":
-		// Same as contain: fit within dimensions
-		if err := resizeContain(vImg, p.Width, p.Height); err != nil {
-			return err
-		}
-	case "outside":
-		// Resize so smallest side matches target
-		if err := resizeOutside(vImg, p.Width, p.Height, origWidth, origHeight); err != nil {
-			return err
-		}
-	default:
-		// Default: simple thumbnail resize
-		if p.Width > 0 || p.Height > 0 {
-			if err := resizeContain(vImg, p.Width, p.Height); err != nil {
-				return err
-			}
-		}
+	if err := applyFit(vImg, fit, p, origWidth, origHeight); err != nil {
+		return err
 	}
 
 	img.Width = vImg.Width()
 	img.Height = vImg.Height()
 	return nil
+}
+
+// applyFit dispatches to the resize strategy named by fit. An unrecognised
+// mode falls back to "contain", which is the least surprising behaviour: the
+// whole image stays visible within the requested box.
+func applyFit(vImg *vips.ImageRef, fit string, p QueryParams, origWidth, origHeight int) error {
+	switch fit {
+	case "cover":
+		// Scale to cover both dimensions, then crop away the overflow.
+		return resizeCover(vImg, p.Width, p.Height, p.Position)
+	case "fill":
+		// Stretch to the exact dimensions, ignoring the aspect ratio.
+		return resizeFill(vImg, p.Width, p.Height, origWidth, origHeight)
+	case "outside":
+		// Scale so the image covers the box on its smallest side.
+		return resizeOutside(vImg, p.Width, p.Height, origWidth, origHeight)
+	case "contain", "inside":
+		return resizeContain(vImg, p.Width, p.Height)
+	default:
+		return resizeContain(vImg, p.Width, p.Height)
+	}
+}
+
+// resizeFill stretches the image to exactly width x height. Both dimensions
+// are required; with only one there is no second scale factor to apply, so the
+// image is left untouched.
+func resizeFill(vImg *vips.ImageRef, width, height, origWidth, origHeight int) error {
+	if width <= 0 || height <= 0 {
+		return nil
+	}
+
+	hScale := float64(width) / float64(origWidth)
+	vScale := float64(height) / float64(origHeight)
+	return vImg.ResizeWithVScale(hScale, vScale, vips.KernelLanczos3)
 }
 
 func resizeCover(vImg *vips.ImageRef, width, height int, position string) error {
@@ -390,101 +396,134 @@ func (img *Image) applyOperations(vImg *vips.ImageRef, p QueryParams) error {
 	}
 
 	if p.Rotate != 0 {
-		// govips Rotate takes a vips.Angle for 90-degree increments
-		switch p.Rotate {
-		case 90:
-			if err := vImg.Rotate(vips.Angle90); err != nil {
-				return fmt.Errorf("rotate: %w", err)
-			}
-		case 180:
-			if err := vImg.Rotate(vips.Angle180); err != nil {
-				return fmt.Errorf("rotate: %w", err)
-			}
-		case 270:
-			if err := vImg.Rotate(vips.Angle270); err != nil {
-				return fmt.Errorf("rotate: %w", err)
-			}
-		default:
-			// For arbitrary angles, use Similarity. The background must not
-			// be nil: govips dereferences it without a check, so passing nil
-			// crashes the process. Transparent black matches what libvips
-			// uses to fill the corners exposed by the rotation.
-			background := &vips.ColorRGBA{}
-			if err := vImg.Similarity(1.0, float64(p.Rotate), background, 0, 0, 0, 0); err != nil {
-				return fmt.Errorf("rotate arbitrary: %w", err)
-			}
+		if err := rotate(vImg, p.Rotate); err != nil {
+			return err
 		}
 	}
 
 	return nil
 }
 
-func (img *Image) convertFormat(vImg *vips.ImageRef, p QueryParams, accept string) error {
-	cfg := &config.Cfg
+// rotate turns the image by degrees. Right-angle turns use the cheap
+// quadrant rotation; anything else goes through an affine transform.
+func rotate(vImg *vips.ImageRef, degrees int) error {
+	quadrants := map[int]vips.Angle{
+		90:  vips.Angle90,
+		180: vips.Angle180,
+		270: vips.Angle270,
+	}
 
+	if angle, ok := quadrants[degrees]; ok {
+		if err := vImg.Rotate(angle); err != nil {
+			return fmt.Errorf("rotate: %w", err)
+		}
+		return nil
+	}
+
+	// For arbitrary angles, use Similarity. The background must not be nil:
+	// govips dereferences it without a check, so passing nil crashes the
+	// process. Transparent black matches what libvips uses to fill the
+	// corners the rotation exposes.
+	background := &vips.ColorRGBA{}
+	if err := vImg.Similarity(1.0, float64(degrees), background, 0, 0, 0, 0); err != nil {
+		return fmt.Errorf("rotate arbitrary: %w", err)
+	}
+	return nil
+}
+
+// convertFormat encodes the processed image, negotiating AVIF or WebP from the
+// client's Accept header and falling back to the source format.
+func (img *Image) convertFormat(vImg *vips.ImageRef, p QueryParams, accept string) error {
 	quality := p.Quality
 	if quality == 0 {
-		quality = cfg.Quality
+		quality = config.Cfg.Quality
 	}
 
-	// Get image dimensions for megapixel check
-	w := vImg.Width()
-	h := vImg.Height()
-	areaMp := float64(w*h) / 1000000.0
+	switch {
+	case img.avifAllowed(vImg, p, accept):
+		return img.exportAvif(vImg, p, quality)
+	case strings.Contains(accept, "image/webp") && config.Cfg.WebP:
+		return img.exportWebp(vImg, p, quality)
+	default:
+		return img.exportNative(vImg)
+	}
+}
 
+// avifAllowed reports whether the result should be encoded as AVIF. AVIF is
+// the best format on offer but also the slowest to encode, so it is limited to
+// still images below a configurable megapixel ceiling — above that, encoding
+// can outlast the Lambda timeout.
+func (img *Image) avifAllowed(vImg *vips.ImageRef, p QueryParams, accept string) bool {
+	if !strings.Contains(accept, "image/avif") || !config.Cfg.AVIF {
+		return false
+	}
+	if img.ContentType == "image/gif" {
+		return false
+	}
+
+	w, h := vImg.Width(), vImg.Height()
+	areaMp := megapixels(w, h)
 	logger.Debug("image dimensions", "width", w, "height", h, "areaMp", areaMp)
 
-	// Check requested dimensions too
-	reqAreaExceeds := false
-	if p.Width > 0 && p.Height > 0 {
-		reqAreaMp := float64(p.Width*p.Height) / 1000000.0
-		reqAreaExceeds = reqAreaMp > cfg.AVIFMaxMP
+	if areaMp > config.Cfg.AVIFMaxMP {
+		return false
+	}
+	// The requested size counts too: a small source upscaled past the ceiling
+	// is just as expensive to encode.
+	if p.Width > 0 && p.Height > 0 && megapixels(p.Width, p.Height) > config.Cfg.AVIFMaxMP {
+		return false
 	}
 
-	maxAreaExceeds := areaMp > cfg.AVIFMaxMP
-	if reqAreaExceeds {
-		maxAreaExceeds = true
+	return true
+}
+
+// megapixels returns the pixel area of width x height in megapixels.
+func megapixels(width, height int) float64 {
+	return float64(width*height) / 1_000_000.0
+}
+
+func (img *Image) exportAvif(vImg *vips.ImageRef, p QueryParams, quality int) error {
+	ep := vips.NewAvifExportParams()
+	ep.Quality = quality
+	if p.Lossless != nil {
+		ep.Lossless = *p.Lossless
+	}
+	if p.WebpEffort > 0 {
+		ep.Speed = p.WebpEffort
 	}
 
-	isGif := img.ContentType == "image/gif"
-
-	if strings.Contains(accept, "image/avif") && !isGif && cfg.AVIF && !maxAreaExceeds {
-		img.ContentType = "image/avif"
-		ep := vips.NewAvifExportParams()
-		ep.Quality = quality
-		if p.Lossless != nil {
-			ep.Lossless = *p.Lossless
-		}
-		if p.WebpEffort > 0 {
-			ep.Speed = p.WebpEffort
-		}
-		buf, _, err := vImg.ExportAvif(ep)
-		if err != nil {
-			return fmt.Errorf("export avif: %w", err)
-		}
-		img.Data = buf
-		return nil
+	buf, _, err := vImg.ExportAvif(ep)
+	if err != nil {
+		return fmt.Errorf("export avif: %w", err)
 	}
 
-	if strings.Contains(accept, "image/webp") && cfg.WebP {
-		img.ContentType = "image/webp"
-		ep := vips.NewWebpExportParams()
-		ep.Quality = quality
-		if p.Lossless != nil {
-			ep.Lossless = *p.Lossless
-		}
-		if p.WebpEffort > 0 {
-			ep.ReductionEffort = p.WebpEffort
-		}
-		buf, _, err := vImg.ExportWebp(ep)
-		if err != nil {
-			return fmt.Errorf("export webp: %w", err)
-		}
-		img.Data = buf
-		return nil
+	img.ContentType = "image/avif"
+	img.Data = buf
+	return nil
+}
+
+func (img *Image) exportWebp(vImg *vips.ImageRef, p QueryParams, quality int) error {
+	ep := vips.NewWebpExportParams()
+	ep.Quality = quality
+	if p.Lossless != nil {
+		ep.Lossless = *p.Lossless
+	}
+	if p.WebpEffort > 0 {
+		ep.ReductionEffort = p.WebpEffort
 	}
 
-	// Export in original format
+	buf, _, err := vImg.ExportWebp(ep)
+	if err != nil {
+		return fmt.Errorf("export webp: %w", err)
+	}
+
+	img.ContentType = "image/webp"
+	img.Data = buf
+	return nil
+}
+
+// exportNative re-encodes the image in the format it arrived in.
+func (img *Image) exportNative(vImg *vips.ImageRef) error {
 	buf, _, err := vImg.ExportNative()
 	if err != nil {
 		return fmt.Errorf("export native: %w", err)

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -1,3 +1,15 @@
+// Package image fetches remote images and applies the requested
+// transformations using libvips through govips.
+//
+// A request follows a fixed pipeline: [Image.IsImage] cheaply rejects URLs
+// that are not images, [Image.Load] downloads the bytes subject to the origin
+// allowlist, and [Image.Process] resizes, applies operations, and encodes the
+// result. Output format is negotiated from the client's Accept header, with
+// AVIF preferred over WebP and a megapixel ceiling that keeps slow AVIF
+// encodes from exhausting the Lambda timeout.
+//
+// Callers must have started libvips with vips.Startup before using this
+// package.
 package image
 
 import (
@@ -12,14 +24,18 @@ import (
 	"time"
 
 	"github.com/davidbyttow/govips/v2/vips"
-	"github.com/zantez/image-api/internal/config"
-	"github.com/zantez/image-api/internal/logger"
+	"github.com/nicobistolfi/eagle-image-api/internal/config"
+	"github.com/nicobistolfi/eagle-image-api/internal/logger"
 )
 
-// ErrOriginNotAllowed is returned when the image URL domain is not in the whitelist.
+// ErrOriginNotAllowed is returned by [Image.Load] when the image URL's domain
+// is not in the configured origin allowlist.
 //
-//lint:ignore ST1005 API contract requires capitalized error message
-var ErrOriginNotAllowed = errors.New("Origin not allowed") //nolint:stylecheck
+// The message is capitalised because it is served verbatim as the HTTP
+// response body, which is part of the API's contract with existing clients.
+//
+//lint:ignore ST1005 the text is a client-facing response body
+var ErrOriginNotAllowed = errors.New("Origin not allowed") //nolint:staticcheck // client-facing message
 
 var defaultHeaders = map[string]string{
 	"User-Agent":                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36",
@@ -389,8 +405,12 @@ func (img *Image) applyOperations(vImg *vips.ImageRef, p QueryParams) error {
 				return fmt.Errorf("rotate: %w", err)
 			}
 		default:
-			// For arbitrary angles, use Similarity with angle
-			if err := vImg.Similarity(1.0, float64(p.Rotate), nil, 0, 0, 0, 0); err != nil {
+			// For arbitrary angles, use Similarity. The background must not
+			// be nil: govips dereferences it without a check, so passing nil
+			// crashes the process. Transparent black matches what libvips
+			// uses to fill the corners exposed by the rotation.
+			background := &vips.ColorRGBA{}
+			if err := vImg.Similarity(1.0, float64(p.Rotate), background, 0, 0, 0, 0); err != nil {
 				return fmt.Errorf("rotate arbitrary: %w", err)
 			}
 		}

--- a/internal/image/image_test.go
+++ b/internal/image/image_test.go
@@ -1,13 +1,89 @@
 package image
 
 import (
+	"bytes"
+	"errors"
+	stdimage "image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
-	"github.com/zantez/image-api/internal/config"
+	"github.com/davidbyttow/govips/v2/vips"
+	"github.com/nicobistolfi/eagle-image-api/internal/config"
 )
 
-func init() {
-	config.Cfg = config.Config{
+func TestMain(m *testing.M) {
+	vips.LoggingSettings(nil, vips.LogLevelError)
+	if err := vips.Startup(nil); err != nil {
+		panic("starting vips: " + err.Error())
+	}
+	code := m.Run()
+	vips.Shutdown()
+	os.Exit(code)
+}
+
+// --- fixtures --------------------------------------------------------------
+
+// makePNG builds a w x h gradient PNG. Real pixel data matters here: libvips
+// decodes lazily, so a malformed fixture only fails later, at export time.
+func makePNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+
+	img := stdimage.NewRGBA(stdimage.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{
+				R: uint8((x * 255) / max(w-1, 1)),
+				G: uint8((y * 255) / max(h-1, 1)),
+				B: 96,
+				A: 255,
+			})
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encoding PNG: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func makeJPEG(t *testing.T, w, h int) []byte {
+	t.Helper()
+
+	img := stdimage.NewRGBA(stdimage.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x), G: uint8(y), B: 200, A: 255})
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, nil); err != nil {
+		t.Fatalf("encoding JPEG: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// newVipsImage loads a fixture into libvips for the low-level resize and
+// operation tests.
+func newVipsImage(t *testing.T, w, h int) *vips.ImageRef {
+	t.Helper()
+	ref, err := vips.NewImageFromBuffer(makePNG(t, w, h))
+	if err != nil {
+		t.Fatalf("loading fixture into vips: %v", err)
+	}
+	t.Cleanup(ref.Close)
+	return ref
+}
+
+func testConfig() config.Config {
+	return config.Config{
 		Environment:     "test",
 		APIEndpoint:     "/api/v1/image",
 		Port:            3000,
@@ -16,132 +92,814 @@ func init() {
 		LogLevel:        "error",
 		OriginWhitelist: "*",
 		AllowAllOrigins: true,
-		RedirectOnError: false,
 		WebP:            true,
 		AVIF:            true,
 		AVIFMaxMP:       2,
 	}
 }
 
+// setConfig installs a test configuration and restores the previous one.
+func setConfig(t *testing.T, c config.Config) {
+	t.Helper()
+	original := config.Cfg
+	config.Cfg = c
+	t.Cleanup(func() { config.Cfg = original })
+}
+
+func init() {
+	config.Cfg = testConfig()
+}
+
+// pngServer serves a generated PNG over HTTP.
+func pngServer(t *testing.T, w, h int) *httptest.Server {
+	t.Helper()
+	data := makePNG(t, w, h)
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.Header().Set("Content-Type", "image/png")
+		_, _ = rw.Write(data)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// --- query parameters ------------------------------------------------------
+
 func TestParseQueryParams(t *testing.T) {
 	m := map[string]string{
-		"url":     "https://example.com/image.jpg",
-		"width":   "200",
-		"height":  "100",
-		"fit":     "cover",
-		"quality": "90",
-		"blur":    "5.5",
-		"flip":    "",
-		"rotate":  "90",
+		"url":          "https://example.com/image.jpg",
+		"width":        "200",
+		"height":       "100",
+		"fit":          "cover",
+		"position":     "attention",
+		"quality":      "90",
+		"blur":         "5.5",
+		"sharpen":      "3.5",
+		"flip":         "",
+		"flop":         "",
+		"rotate":       "90",
+		"alphaQuality": "70",
+		"loop":         "3",
+		"delay":        "120",
+		"webpEffort":   "5",
+		"background":   "#ffffff",
+		"kernel":       "lanczos3",
 	}
 
 	p := ParseQueryParams(m)
 
-	if p.URL != "https://example.com/image.jpg" {
-		t.Errorf("expected URL https://example.com/image.jpg, got %s", p.URL)
+	checks := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"URL", p.URL, "https://example.com/image.jpg"},
+		{"Width", p.Width, 200},
+		{"Height", p.Height, 100},
+		{"Fit", p.Fit, "cover"},
+		{"Position", p.Position, "attention"},
+		{"Quality", p.Quality, 90},
+		{"Blur", p.Blur, 5.5},
+		{"Sharpen", p.Sharpen, 3.5},
+		{"Flip", p.Flip, true},
+		{"Flop", p.Flop, true},
+		{"Rotate", p.Rotate, 90},
+		{"AlphaQuality", p.AlphaQuality, 70},
+		{"Loop", p.Loop, 3},
+		{"Delay", p.Delay, 120},
+		{"WebpEffort", p.WebpEffort, 5},
+		{"Background", p.Background, "#ffffff"},
+		{"Kernel", p.Kernel, "lanczos3"},
 	}
-	if p.Width != 200 {
-		t.Errorf("expected width 200, got %d", p.Width)
-	}
-	if p.Height != 100 {
-		t.Errorf("expected height 100, got %d", p.Height)
-	}
-	if p.Fit != "cover" {
-		t.Errorf("expected fit cover, got %s", p.Fit)
-	}
-	if p.Quality != 90 {
-		t.Errorf("expected quality 90, got %d", p.Quality)
-	}
-	if p.Blur != 5.5 {
-		t.Errorf("expected blur 5.5, got %f", p.Blur)
-	}
-	if !p.Flip {
-		t.Error("expected flip to be true")
-	}
-	if p.Rotate != 90 {
-		t.Errorf("expected rotate 90, got %d", p.Rotate)
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %v, want %v", c.name, c.got, c.want)
+		}
 	}
 }
 
 func TestParseQueryParamsLossless(t *testing.T) {
-	m := map[string]string{
-		"url":      "https://example.com/image.jpg",
-		"lossless": "true",
-	}
-	p := ParseQueryParams(m)
-	if p.Lossless == nil || !*p.Lossless {
-		t.Error("expected lossless to be true")
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"true", true},
+		{"TRUE", true},
+		{"1", true},
+		{"false", false},
+		{"0", false},
+		{"anything else", false},
 	}
 
-	m["lossless"] = "0"
-	p = ParseQueryParams(m)
-	if p.Lossless == nil || *p.Lossless {
-		t.Error("expected lossless to be false for '0'")
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			p := ParseQueryParams(map[string]string{"lossless": tt.value})
+			if p.Lossless == nil {
+				t.Fatal("Lossless = nil, want a value when the parameter is present")
+			}
+			if *p.Lossless != tt.want {
+				t.Errorf("Lossless = %v, want %v", *p.Lossless, tt.want)
+			}
+		})
 	}
 }
 
 func TestParseQueryParamsEmpty(t *testing.T) {
-	m := map[string]string{
-		"url": "https://example.com/image.jpg",
+	p := ParseQueryParams(map[string]string{"url": "https://example.com/image.jpg"})
+
+	if p.Width != 0 || p.Height != 0 || p.Quality != 0 {
+		t.Errorf("expected zero dimensions and quality, got %+v", p)
 	}
-	p := ParseQueryParams(m)
-	if p.Width != 0 {
-		t.Errorf("expected width 0, got %d", p.Width)
+	if p.Flip || p.Flop {
+		t.Error("expected flip and flop to be false when absent")
 	}
-	if p.Flip {
-		t.Error("expected flip to be false")
-	}
+	// nil rather than false: absent must stay distinguishable from
+	// lossless=false so the encoder default is preserved.
 	if p.Lossless != nil {
-		t.Error("expected lossless to be nil")
+		t.Error("Lossless should be nil when the parameter is absent")
 	}
 }
 
+// TestParseQueryParamsIgnoresMalformedNumbers documents that a bad numeric
+// value degrades to the zero value rather than failing the request.
+func TestParseQueryParamsIgnoresMalformedNumbers(t *testing.T) {
+	p := ParseQueryParams(map[string]string{
+		"width":   "wide",
+		"height":  "",
+		"quality": "high",
+		"blur":    "lots",
+		"rotate":  "sideways",
+	})
+
+	if p.Width != 0 || p.Height != 0 || p.Quality != 0 || p.Blur != 0 || p.Rotate != 0 {
+		t.Errorf("expected malformed values to fall back to zero, got %+v", p)
+	}
+}
+
+// --- helpers ---------------------------------------------------------------
+
 func TestExtractDomain(t *testing.T) {
-	tests := []struct {
-		url    string
-		domain string
-	}{
+	tests := []struct{ url, domain string }{
 		{"https://example.com/path/image.jpg", "example.com"},
 		{"http://cdn.example.com/img.png", "cdn.example.com"},
+		{"https://example.com:8080/img.png", "example.com:8080"},
 		{"invalid", ""},
+		{"", ""},
 	}
 
 	for _, tt := range tests {
-		got := extractDomain(tt.url)
-		if got != tt.domain {
+		if got := extractDomain(tt.url); got != tt.domain {
 			t.Errorf("extractDomain(%q) = %q, want %q", tt.url, got, tt.domain)
 		}
 	}
 }
 
+func TestParseInterest(t *testing.T) {
+	tests := []struct {
+		position string
+		want     vips.Interesting
+	}{
+		{"centre", vips.InterestingCentre},
+		{"center", vips.InterestingCentre},
+		{"CENTER", vips.InterestingCentre},
+		{"entropy", vips.InterestingEntropy},
+		{"attention", vips.InterestingAttention},
+		{"", vips.InterestingCentre},
+		{"nonsense", vips.InterestingCentre},
+	}
+
+	for _, tt := range tests {
+		if got := parseInterest(tt.position); got != tt.want {
+			t.Errorf("parseInterest(%q) = %v, want %v", tt.position, got, tt.want)
+		}
+	}
+}
+
+func TestNew(t *testing.T) {
+	img := New("https://example.com/a.png")
+	if img.URL != "https://example.com/a.png" {
+		t.Errorf("URL = %q", img.URL)
+	}
+	if img.Data != nil {
+		t.Error("expected no data before Load")
+	}
+}
+
 func TestResponseHeaders(t *testing.T) {
-	img := &Image{
-		ContentType: "image/webp",
-		Data:        make([]byte, 1024),
-	}
+	img := &Image{ContentType: "image/webp", Data: make([]byte, 1024)}
 
-	headers := img.ResponseHeaders()
+	h := img.ResponseHeaders()
 
-	if headers["Content-Type"] != "image/webp" {
-		t.Errorf("expected Content-Type image/webp, got %s", headers["Content-Type"])
+	if h["Content-Type"] != "image/webp" {
+		t.Errorf("Content-Type = %q", h["Content-Type"])
 	}
-	if headers["Content-Length"] != "1024" {
-		t.Errorf("expected Content-Length 1024, got %s", headers["Content-Length"])
+	if h["Content-Length"] != "1024" {
+		t.Errorf("Content-Length = %q, want 1024", h["Content-Length"])
 	}
-	if headers["Cache-Control"] != "public, max-age=31536000" {
-		t.Errorf("unexpected Cache-Control: %s", headers["Cache-Control"])
+	if h["Cache-Control"] != "public, max-age=31536000" {
+		t.Errorf("Cache-Control = %q", h["Cache-Control"])
 	}
-	if headers["X-Powered-By"] != "Image API" {
-		t.Errorf("unexpected X-Powered-By: %s", headers["X-Powered-By"])
+	if h["X-Powered-By"] != "Image API" {
+		t.Errorf("X-Powered-By = %q", h["X-Powered-By"])
+	}
+	for _, k := range []string{"Expires", "Last-Modified", "Pragma"} {
+		if h[k] == "" {
+			t.Errorf("missing %s header", k)
+		}
 	}
 }
 
 func TestBase64(t *testing.T) {
-	img := &Image{
-		Data: []byte("hello"),
+	img := &Image{Data: []byte("hello")}
+	if got := img.Base64(); got != "aGVsbG8=" {
+		t.Errorf("Base64() = %q, want aGVsbG8=", got)
 	}
-	expected := "aGVsbG8="
-	if got := img.Base64(); got != expected {
-		t.Errorf("Base64() = %q, want %q", got, expected)
+}
+
+// --- fetching --------------------------------------------------------------
+
+func TestIsImage(t *testing.T) {
+	srv := pngServer(t, 8, 8)
+
+	ok, err := New(srv.URL + "/a.png").IsImage()
+	if err != nil {
+		t.Fatalf("IsImage() error: %v", err)
+	}
+	if !ok {
+		t.Error("IsImage() = false, want true for an image/png response")
+	}
+}
+
+func TestIsImageNonImage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	}))
+	defer srv.Close()
+
+	ok, err := New(srv.URL).IsImage()
+	if err != nil {
+		t.Fatalf("IsImage() error: %v", err)
+	}
+	if ok {
+		t.Error("IsImage() = true, want false for text/html")
+	}
+}
+
+func TestIsImageErrors(t *testing.T) {
+	t.Run("malformed url", func(t *testing.T) {
+		if _, err := New("://not a url").IsImage(); err == nil {
+			t.Fatal("expected an error for a malformed URL")
+		}
+	})
+
+	t.Run("connection refused", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		url := srv.URL
+		srv.Close()
+
+		if _, err := New(url).IsImage(); err == nil {
+			t.Fatal("expected an error when the host is unreachable")
+		}
+	})
+}
+
+func TestLoad(t *testing.T) {
+	setConfig(t, testConfig())
+	srv := pngServer(t, 16, 16)
+
+	img := New(srv.URL + "/a.png")
+	if err := img.Load(); err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if len(img.Data) == 0 {
+		t.Error("expected image data after Load")
+	}
+	if img.ContentType != "image/png" {
+		t.Errorf("ContentType = %q, want image/png", img.ContentType)
+	}
+}
+
+func TestLoadOriginNotAllowed(t *testing.T) {
+	c := testConfig()
+	c.AllowAllOrigins = false
+	c.Origins = []string{"allowed.example.com"}
+	setConfig(t, c)
+
+	err := New("https://blocked.example.com/a.png").Load()
+	if err == nil {
+		t.Fatal("expected an error for a disallowed origin")
+	}
+	if !errors.Is(err, ErrOriginNotAllowed) {
+		t.Errorf("error = %v, want ErrOriginNotAllowed", err)
+	}
+}
+
+func TestLoadOriginAllowedByWhitelist(t *testing.T) {
+	srv := pngServer(t, 8, 8)
+
+	c := testConfig()
+	c.AllowAllOrigins = false
+	c.Origins = []string{strings.TrimPrefix(srv.URL, "http://")}
+	setConfig(t, c)
+
+	if err := New(srv.URL + "/a.png").Load(); err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+}
+
+func TestLoadErrors(t *testing.T) {
+	setConfig(t, testConfig())
+
+	t.Run("malformed url", func(t *testing.T) {
+		if err := New("://not a url").Load(); err == nil {
+			t.Fatal("expected an error for a malformed URL")
+		}
+	})
+
+	t.Run("connection refused", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		url := srv.URL
+		srv.Close()
+
+		if err := New(url).Load(); err == nil {
+			t.Fatal("expected an error when the host is unreachable")
+		}
+	})
+}
+
+// --- resizing --------------------------------------------------------------
+
+func TestResizeFitModes(t *testing.T) {
+	setConfig(t, testConfig())
+
+	// The 200x100 source has a 2:1 aspect ratio, which makes every mode
+	// produce a distinguishable result for a 50x50 request.
+	tests := []struct {
+		name         string
+		params       QueryParams
+		wantW, wantH int
+	}{
+		{"cover crops to exact size", QueryParams{Width: 50, Height: 50, Fit: "cover"}, 50, 50},
+		{"fill forces exact size", QueryParams{Width: 60, Height: 30, Fit: "fill"}, 60, 30},
+		{"contain fits inside", QueryParams{Width: 50, Height: 50, Fit: "contain"}, 50, 25},
+		{"inside behaves like contain", QueryParams{Width: 50, Height: 50, Fit: "inside"}, 50, 25},
+		{"outside covers the box", QueryParams{Width: 50, Height: 50, Fit: "outside"}, 100, 50},
+		{"unknown fit falls back to contain", QueryParams{Width: 50, Height: 50, Fit: "bogus"}, 50, 25},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref := newVipsImage(t, 200, 100)
+			img := &Image{}
+
+			if err := img.resize(ref, tt.params); err != nil {
+				t.Fatalf("resize() error: %v", err)
+			}
+			if ref.Width() != tt.wantW || ref.Height() != tt.wantH {
+				t.Errorf("size = %dx%d, want %dx%d", ref.Width(), ref.Height(), tt.wantW, tt.wantH)
+			}
+			if img.Width != ref.Width() || img.Height != ref.Height() {
+				t.Errorf("Image dimensions %dx%d out of sync with vips %dx%d",
+					img.Width, img.Height, ref.Width(), ref.Height())
+			}
+		})
+	}
+}
+
+func TestResizeNoDimensionsIsNoOp(t *testing.T) {
+	setConfig(t, testConfig())
+	ref := newVipsImage(t, 120, 80)
+	img := &Image{}
+
+	if err := img.resize(ref, QueryParams{}); err != nil {
+		t.Fatalf("resize() error: %v", err)
+	}
+	if ref.Width() != 120 || ref.Height() != 80 {
+		t.Errorf("size = %dx%d, want the original 120x80", ref.Width(), ref.Height())
+	}
+	if img.Width != 0 || img.Height != 0 {
+		t.Error("expected dimensions to stay unset when no resize happens")
+	}
+}
+
+func TestResizeUsesConfiguredDefaultFit(t *testing.T) {
+	c := testConfig()
+	c.Fit = "fill"
+	setConfig(t, c)
+
+	ref := newVipsImage(t, 200, 100)
+	img := &Image{}
+
+	// No fit in the request, so the configured default must apply.
+	if err := img.resize(ref, QueryParams{Width: 40, Height: 40}); err != nil {
+		t.Fatalf("resize() error: %v", err)
+	}
+	if ref.Width() != 40 || ref.Height() != 40 {
+		t.Errorf("size = %dx%d, want 40x40 from the configured fill default", ref.Width(), ref.Height())
+	}
+}
+
+func TestResizeSingleDimension(t *testing.T) {
+	setConfig(t, testConfig())
+
+	tests := []struct {
+		name         string
+		params       QueryParams
+		wantW, wantH int
+	}{
+		{"cover width only", QueryParams{Width: 100, Fit: "cover"}, 100, 50},
+		{"cover height only", QueryParams{Height: 25, Fit: "cover"}, 50, 25},
+		{"contain width only", QueryParams{Width: 100, Fit: "contain"}, 100, 50},
+		{"contain height only", QueryParams{Height: 25, Fit: "contain"}, 50, 25},
+		{"outside width only", QueryParams{Width: 100, Fit: "outside"}, 100, 50},
+		{"outside height only", QueryParams{Height: 25, Fit: "outside"}, 50, 25},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref := newVipsImage(t, 200, 100)
+			img := &Image{}
+
+			if err := img.resize(ref, tt.params); err != nil {
+				t.Fatalf("resize() error: %v", err)
+			}
+			if ref.Width() != tt.wantW || ref.Height() != tt.wantH {
+				t.Errorf("size = %dx%d, want %dx%d", ref.Width(), ref.Height(), tt.wantW, tt.wantH)
+			}
+		})
+	}
+}
+
+// TestFillNeedsBothDimensions documents that fill requires a width and a
+// height; with only one it leaves the image untouched.
+func TestFillNeedsBothDimensions(t *testing.T) {
+	setConfig(t, testConfig())
+	ref := newVipsImage(t, 200, 100)
+	img := &Image{}
+
+	if err := img.resize(ref, QueryParams{Width: 50, Fit: "fill"}); err != nil {
+		t.Fatalf("resize() error: %v", err)
+	}
+	if ref.Width() != 200 || ref.Height() != 100 {
+		t.Errorf("size = %dx%d, want the original 200x100", ref.Width(), ref.Height())
+	}
+}
+
+func TestResizeHelpersWithNoTarget(t *testing.T) {
+	ref := newVipsImage(t, 40, 40)
+
+	if err := resizeContain(ref, 0, 0); err != nil {
+		t.Fatalf("resizeContain() error: %v", err)
+	}
+	if err := resizeOutside(ref, 0, 0, 40, 40); err != nil {
+		t.Fatalf("resizeOutside() error: %v", err)
+	}
+	if ref.Width() != 40 || ref.Height() != 40 {
+		t.Errorf("size = %dx%d, want the original 40x40", ref.Width(), ref.Height())
+	}
+}
+
+func TestCoverWithPosition(t *testing.T) {
+	setConfig(t, testConfig())
+
+	for _, position := range []string{"centre", "entropy", "attention", ""} {
+		name := position
+		if name == "" {
+			name = "unset"
+		}
+		t.Run(name, func(t *testing.T) {
+			ref := newVipsImage(t, 200, 100)
+			img := &Image{}
+
+			err := img.resize(ref, QueryParams{Width: 40, Height: 40, Fit: "cover", Position: position})
+			if err != nil {
+				t.Fatalf("resize() error: %v", err)
+			}
+			if ref.Width() != 40 || ref.Height() != 40 {
+				t.Errorf("size = %dx%d, want 40x40", ref.Width(), ref.Height())
+			}
+		})
+	}
+}
+
+// --- operations ------------------------------------------------------------
+
+func TestApplyOperations(t *testing.T) {
+	tests := []struct {
+		name   string
+		params QueryParams
+	}{
+		{"blur", QueryParams{Blur: 3}},
+		{"sharpen", QueryParams{Sharpen: 5}},
+		{"flip", QueryParams{Flip: true}},
+		{"flop", QueryParams{Flop: true}},
+		{"flip and flop", QueryParams{Flip: true, Flop: true}},
+		{"rotate 90", QueryParams{Rotate: 90}},
+		{"rotate 180", QueryParams{Rotate: 180}},
+		{"rotate 270", QueryParams{Rotate: 270}},
+		{"rotate arbitrary", QueryParams{Rotate: 45}},
+		{"no operations", QueryParams{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref := newVipsImage(t, 40, 20)
+			img := &Image{}
+
+			if err := img.applyOperations(ref, tt.params); err != nil {
+				t.Fatalf("applyOperations() error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRotate90SwapsDimensions(t *testing.T) {
+	ref := newVipsImage(t, 40, 20)
+	img := &Image{}
+
+	if err := img.applyOperations(ref, QueryParams{Rotate: 90}); err != nil {
+		t.Fatalf("applyOperations() error: %v", err)
+	}
+	if ref.Width() != 20 || ref.Height() != 40 {
+		t.Errorf("size = %dx%d, want 20x40 after a 90 degree rotation", ref.Width(), ref.Height())
+	}
+}
+
+// TestOperationsOutOfRangeAreSkipped covers the guard rails: values outside
+// the accepted range are ignored rather than handed to libvips.
+func TestOperationsOutOfRangeAreSkipped(t *testing.T) {
+	tests := []struct {
+		name   string
+		params QueryParams
+	}{
+		{"blur above range", QueryParams{Blur: 500}},
+		{"blur zero", QueryParams{Blur: 0}},
+		{"blur negative", QueryParams{Blur: -5}},
+		{"sharpen at lower bound", QueryParams{Sharpen: 1}},
+		{"sharpen above range", QueryParams{Sharpen: 500}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref := newVipsImage(t, 20, 20)
+			img := &Image{}
+
+			if err := img.applyOperations(ref, tt.params); err != nil {
+				t.Fatalf("applyOperations() error: %v", err)
+			}
+		})
+	}
+}
+
+// --- format conversion -----------------------------------------------------
+
+func TestConvertFormatNative(t *testing.T) {
+	setConfig(t, testConfig())
+	ref := newVipsImage(t, 20, 20)
+	img := &Image{ContentType: "image/png"}
+
+	if err := img.convertFormat(ref, QueryParams{}, ""); err != nil {
+		t.Fatalf("convertFormat() error: %v", err)
+	}
+	if img.ContentType != "image/png" {
+		t.Errorf("ContentType = %q, want the original image/png", img.ContentType)
+	}
+	if len(img.Data) == 0 {
+		t.Error("expected encoded data")
+	}
+}
+
+func TestConvertFormatWebP(t *testing.T) {
+	setConfig(t, testConfig())
+	ref := newVipsImage(t, 20, 20)
+	img := &Image{ContentType: "image/png"}
+
+	if err := img.convertFormat(ref, QueryParams{}, "image/webp,*/*"); err != nil {
+		t.Fatalf("convertFormat() error: %v", err)
+	}
+	if img.ContentType != "image/webp" {
+		t.Errorf("ContentType = %q, want image/webp", img.ContentType)
+	}
+}
+
+func TestConvertFormatModernFormatsDisabled(t *testing.T) {
+	c := testConfig()
+	c.WebP = false
+	c.AVIF = false
+	setConfig(t, c)
+
+	ref := newVipsImage(t, 20, 20)
+	img := &Image{ContentType: "image/png"}
+
+	if err := img.convertFormat(ref, QueryParams{}, "image/webp,image/avif"); err != nil {
+		t.Fatalf("convertFormat() error: %v", err)
+	}
+	if img.ContentType != "image/png" {
+		t.Errorf("ContentType = %q, want image/png when WebP and AVIF are disabled", img.ContentType)
+	}
+}
+
+func TestConvertFormatWebPWithOptions(t *testing.T) {
+	setConfig(t, testConfig())
+	lossless := true
+	ref := newVipsImage(t, 20, 20)
+	img := &Image{ContentType: "image/png"}
+
+	params := QueryParams{Quality: 60, Lossless: &lossless, WebpEffort: 4}
+	if err := img.convertFormat(ref, params, "image/webp"); err != nil {
+		t.Fatalf("convertFormat() error: %v", err)
+	}
+	if img.ContentType != "image/webp" {
+		t.Errorf("ContentType = %q, want image/webp", img.ContentType)
+	}
+}
+
+// TestConvertFormatGifSkipsAVIF checks animated content is not sent through
+// the AVIF encoder, falling through to WebP instead.
+func TestConvertFormatGifSkipsAVIF(t *testing.T) {
+	setConfig(t, testConfig())
+	ref := newVipsImage(t, 20, 20)
+	img := &Image{ContentType: "image/gif"}
+
+	if err := img.convertFormat(ref, QueryParams{}, "image/avif,image/webp"); err != nil {
+		t.Fatalf("convertFormat() error: %v", err)
+	}
+	if img.ContentType != "image/webp" {
+		t.Errorf("ContentType = %q, want image/webp for a GIF source", img.ContentType)
+	}
+}
+
+// TestConvertFormatAVIFSkippedWhenTooLarge covers the megapixel guard that
+// keeps slow AVIF encodes from timing out the Lambda.
+func TestConvertFormatAVIFSkippedWhenTooLarge(t *testing.T) {
+	c := testConfig()
+	c.AVIFMaxMP = 0.0001 // any real image exceeds this
+	setConfig(t, c)
+
+	ref := newVipsImage(t, 100, 100)
+	img := &Image{ContentType: "image/png"}
+
+	if err := img.convertFormat(ref, QueryParams{}, "image/avif,image/webp"); err != nil {
+		t.Fatalf("convertFormat() error: %v", err)
+	}
+	if img.ContentType != "image/webp" {
+		t.Errorf("ContentType = %q, want image/webp above the AVIF limit", img.ContentType)
+	}
+}
+
+// TestConvertFormatAVIFSkippedForLargeRequestedSize checks the guard also
+// considers the requested output size, not just the current one.
+func TestConvertFormatAVIFSkippedForLargeRequestedSize(t *testing.T) {
+	c := testConfig()
+	c.AVIFMaxMP = 1
+	setConfig(t, c)
+
+	ref := newVipsImage(t, 20, 20) // small right now...
+	img := &Image{ContentType: "image/png"}
+
+	// ...but 2000x2000 was requested, which is 4 MP.
+	params := QueryParams{Width: 2000, Height: 2000}
+	if err := img.convertFormat(ref, params, "image/avif,image/webp"); err != nil {
+		t.Fatalf("convertFormat() error: %v", err)
+	}
+	if img.ContentType != "image/webp" {
+		t.Errorf("ContentType = %q, want image/webp above the AVIF limit", img.ContentType)
+	}
+}
+
+func TestConvertFormatAVIF(t *testing.T) {
+	setConfig(t, testConfig())
+	ref := newVipsImage(t, 20, 20)
+	img := &Image{ContentType: "image/png"}
+
+	err := img.convertFormat(ref, QueryParams{Quality: 50, WebpEffort: 6}, "image/avif,image/webp")
+	if err != nil {
+		// Not every libvips build ships an AVIF encoder.
+		t.Skipf("AVIF encoding unavailable in this libvips build: %v", err)
+	}
+	if img.ContentType != "image/avif" {
+		t.Errorf("ContentType = %q, want image/avif", img.ContentType)
+	}
+	if len(img.Data) == 0 {
+		t.Error("expected encoded AVIF data")
+	}
+}
+
+func TestConvertFormatAVIFLossless(t *testing.T) {
+	setConfig(t, testConfig())
+	lossless := true
+	ref := newVipsImage(t, 20, 20)
+	img := &Image{ContentType: "image/png"}
+
+	err := img.convertFormat(ref, QueryParams{Lossless: &lossless}, "image/avif")
+	if err != nil {
+		t.Skipf("AVIF encoding unavailable in this libvips build: %v", err)
+	}
+	if img.ContentType != "image/avif" {
+		t.Errorf("ContentType = %q, want image/avif", img.ContentType)
+	}
+}
+
+// TestConvertFormatDefaultQuality checks the configured quality applies when
+// the request does not carry one.
+func TestConvertFormatDefaultQuality(t *testing.T) {
+	c := testConfig()
+	c.Quality = 10
+	setConfig(t, c)
+
+	ref := newVipsImage(t, 80, 80)
+	lowQ := &Image{ContentType: "image/png"}
+	if err := lowQ.convertFormat(ref, QueryParams{}, "image/webp"); err != nil {
+		t.Fatalf("convertFormat() error: %v", err)
+	}
+
+	ref2 := newVipsImage(t, 80, 80)
+	highQ := &Image{ContentType: "image/png"}
+	if err := highQ.convertFormat(ref2, QueryParams{Quality: 95}, "image/webp"); err != nil {
+		t.Fatalf("convertFormat() error: %v", err)
+	}
+
+	if len(lowQ.Data) >= len(highQ.Data) {
+		t.Errorf("quality 10 produced %d bytes and quality 95 produced %d; expected the configured default to be applied",
+			len(lowQ.Data), len(highQ.Data))
+	}
+}
+
+// --- end to end ------------------------------------------------------------
+
+func TestProcess(t *testing.T) {
+	setConfig(t, testConfig())
+
+	img := &Image{ContentType: "image/png", Data: makePNG(t, 200, 100)}
+	params := QueryParams{Width: 50, Height: 50, Fit: "cover", Blur: 2, Rotate: 90}
+
+	if err := img.Process(params, "image/webp"); err != nil {
+		t.Fatalf("Process() error: %v", err)
+	}
+	if img.ContentType != "image/webp" {
+		t.Errorf("ContentType = %q, want image/webp", img.ContentType)
+	}
+	if len(img.Data) == 0 {
+		t.Error("expected processed data")
+	}
+}
+
+func TestProcessJPEG(t *testing.T) {
+	setConfig(t, testConfig())
+
+	img := &Image{ContentType: "image/jpeg", Data: makeJPEG(t, 120, 80)}
+	if err := img.Process(QueryParams{Width: 40}, ""); err != nil {
+		t.Fatalf("Process() error: %v", err)
+	}
+	if img.Width != 40 {
+		t.Errorf("Width = %d, want 40", img.Width)
+	}
+}
+
+func TestProcessInvalidData(t *testing.T) {
+	setConfig(t, testConfig())
+
+	img := &Image{ContentType: "image/png", Data: []byte("not an image at all")}
+	err := img.Process(QueryParams{}, "")
+	if err == nil {
+		t.Fatal("expected an error for undecodable data")
+	}
+	if !strings.Contains(err.Error(), "loading image into vips") {
+		t.Errorf("error = %v, want it to identify the load step", err)
+	}
+}
+
+// TestLoadThenProcess exercises the full fetch-and-transform path a request
+// takes, against a real HTTP server.
+func TestLoadThenProcess(t *testing.T) {
+	setConfig(t, testConfig())
+	srv := pngServer(t, 300, 150)
+
+	img := New(srv.URL + "/a.png")
+
+	ok, err := img.IsImage()
+	if err != nil {
+		t.Fatalf("IsImage() error: %v", err)
+	}
+	if !ok {
+		t.Fatal("IsImage() = false, want true")
+	}
+	if err := img.Load(); err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if err := img.Process(QueryParams{Width: 100, Fit: "contain"}, "image/webp"); err != nil {
+		t.Fatalf("Process() error: %v", err)
+	}
+
+	if img.Width != 100 || img.Height != 50 {
+		t.Errorf("size = %dx%d, want 100x50", img.Width, img.Height)
+	}
+	if img.ContentType != "image/webp" {
+		t.Errorf("ContentType = %q, want image/webp", img.ContentType)
+	}
+	if img.Base64() == "" {
+		t.Error("expected a base64 body")
+	}
+	if img.ResponseHeaders()["Content-Type"] != "image/webp" {
+		t.Error("response headers should reflect the negotiated content type")
 	}
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,41 +1,65 @@
+// Package logger configures the application-wide structured logger.
+//
+// Init installs a slog text handler on the standard library's default logger,
+// so any package that calls slog directly shares the same configuration. The
+// Debug, Info, and Error helpers are thin wrappers kept for convenience and to
+// keep call sites free of a slog import.
 package logger
 
 import (
+	"io"
 	"log/slog"
 	"os"
 	"strings"
 )
 
-// Init configures the default slog logger with the given level string.
-func Init(level string) {
-	var l slog.Level
-	switch strings.ToLower(level) {
+// ParseLevel maps a human-readable level name to a [slog.Level].
+//
+// Recognised names are "silly", "debug", "info", "warn", "warning", and
+// "error", matched case-insensitively. Any unrecognised value — including the
+// empty string — falls back to [slog.LevelDebug], which favours visibility
+// over silence when the level is misconfigured.
+func ParseLevel(level string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(level)) {
 	case "silly", "debug":
-		l = slog.LevelDebug
+		return slog.LevelDebug
 	case "info":
-		l = slog.LevelInfo
+		return slog.LevelInfo
 	case "warn", "warning":
-		l = slog.LevelWarn
+		return slog.LevelWarn
 	case "error":
-		l = slog.LevelError
+		return slog.LevelError
 	default:
-		l = slog.LevelDebug
+		return slog.LevelDebug
 	}
+}
 
-	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
-		Level: l,
+// Init configures the default slog logger to write text records to stdout at
+// the level named by level. See [ParseLevel] for the accepted names.
+func Init(level string) {
+	InitWithWriter(os.Stdout, level)
+}
+
+// InitWithWriter behaves like [Init] but sends records to w. It exists so
+// tests and embedders can capture log output.
+func InitWithWriter(w io.Writer, level string) {
+	handler := slog.NewTextHandler(w, &slog.HandlerOptions{
+		Level: ParseLevel(level),
 	})
 	slog.SetDefault(slog.New(handler))
 }
 
+// Debug logs msg at debug level with the given key/value pairs.
 func Debug(msg string, args ...any) {
 	slog.Debug(msg, args...)
 }
 
+// Info logs msg at info level with the given key/value pairs.
 func Info(msg string, args ...any) {
 	slog.Info(msg, args...)
 }
 
+// Error logs msg at error level with the given key/value pairs.
 func Error(msg string, args ...any) {
 	slog.Error(msg, args...)
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,91 @@
+package logger
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestParseLevel(t *testing.T) {
+	tests := []struct {
+		in   string
+		want slog.Level
+	}{
+		{"silly", slog.LevelDebug},
+		{"debug", slog.LevelDebug},
+		{"DEBUG", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+		{"Info", slog.LevelInfo},
+		{"warn", slog.LevelWarn},
+		{"warning", slog.LevelWarn},
+		{"WARNING", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{" error ", slog.LevelError},
+		{"", slog.LevelDebug},
+		{"nonsense", slog.LevelDebug},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := ParseLevel(tt.in); got != tt.want {
+				t.Errorf("ParseLevel(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInitWithWriterFiltersBelowLevel(t *testing.T) {
+	var buf bytes.Buffer
+	InitWithWriter(&buf, "warn")
+
+	Debug("debug message")
+	Info("info message")
+	Error("error message")
+
+	out := buf.String()
+	if strings.Contains(out, "debug message") {
+		t.Error("debug record should be filtered out at warn level")
+	}
+	if strings.Contains(out, "info message") {
+		t.Error("info record should be filtered out at warn level")
+	}
+	if !strings.Contains(out, "error message") {
+		t.Errorf("error record should be emitted at warn level, got %q", out)
+	}
+}
+
+func TestInitWithWriterEmitsAttributes(t *testing.T) {
+	var buf bytes.Buffer
+	InitWithWriter(&buf, "debug")
+
+	Debug("fetching", "url", "https://example.com/a.jpg")
+	Info("processed", "bytes", 1024)
+
+	out := buf.String()
+	for _, want := range []string{
+		`msg=fetching`,
+		`url=https://example.com/a.jpg`,
+		`msg=processed`,
+		`bytes=1024`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q, got %q", want, out)
+		}
+	}
+}
+
+func TestInitUsesStdout(t *testing.T) {
+	// Init is a thin wrapper over InitWithWriter; exercise it so the default
+	// wiring is covered and cannot silently break.
+	Init("info")
+
+	ctx := context.Background()
+	if !slog.Default().Enabled(ctx, slog.LevelInfo) {
+		t.Error(`expected info level to be enabled after Init("info")`)
+	}
+	if slog.Default().Enabled(ctx, slog.LevelDebug) {
+		t.Error(`expected debug level to be disabled after Init("info")`)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,21 +1,37 @@
+// Command eagle-image-api is the AWS Lambda entry point for the Eagle image
+// optimization and transformation service.
+//
+// Configuration comes entirely from environment variables; see the config
+// package for the full list. The binary loads that configuration, starts
+// libvips, and hands requests to the handler package.
 package main
 
 import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/davidbyttow/govips/v2/vips"
-	"github.com/zantez/image-api/internal/config"
-	"github.com/zantez/image-api/internal/handler"
-	"github.com/zantez/image-api/internal/logger"
+	"github.com/nicobistolfi/eagle-image-api/internal/config"
+	"github.com/nicobistolfi/eagle-image-api/internal/handler"
+	"github.com/nicobistolfi/eagle-image-api/internal/logger"
 )
 
-func main() {
+// setup loads configuration, installs the logger, and starts libvips. The
+// returned function releases the libvips resources.
+func setup() (shutdown func(), err error) {
 	config.Load()
 	logger.Init(config.Cfg.LogLevel)
 
 	if err := vips.Startup(nil); err != nil {
+		return nil, err
+	}
+	return vips.Shutdown, nil
+}
+
+func main() {
+	shutdown, err := setup()
+	if err != nil {
 		panic("failed to start vips: " + err.Error())
 	}
-	defer vips.Shutdown()
+	defer shutdown()
 
 	lambda.Start(handler.Handle)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/nicobistolfi/eagle-image-api/internal/config"
+)
+
+// TestSetup covers the startup path main() depends on: configuration is read
+// from the environment and libvips comes up cleanly.
+func TestSetup(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "error")
+	t.Setenv("QUALITY", "70")
+
+	shutdown, err := setup()
+	if err != nil {
+		t.Fatalf("setup() error: %v", err)
+	}
+	if shutdown == nil {
+		t.Fatal("setup() returned a nil shutdown function")
+	}
+	defer shutdown()
+
+	if config.Cfg.LogLevel != "error" {
+		t.Errorf("LogLevel = %q, want error", config.Cfg.LogLevel)
+	}
+	if config.Cfg.Quality != 70 {
+		t.Errorf("Quality = %d, want 70", config.Cfg.Quality)
+	}
+}

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Smoke test a deployed Eagle Image API.
+#
+# Checks that the deployment answers on its health endpoint, transforms a real
+# image, negotiates WebP from the Accept header, and rejects bad requests. It
+# is deliberately shallow: it proves the stack is wired together and serving,
+# not that every transformation is correct — the Go test suite covers that.
+#
+# Usage:
+#   scripts/smoke-test.sh <base-url> [api-endpoint]
+#
+# Example:
+#   scripts/smoke-test.sh https://abc123.execute-api.us-west-1.amazonaws.com/dev
+#
+set -euo pipefail
+
+BASE_URL="${1:-}"
+API_ENDPOINT="${2:-/api/v1/image}"
+TEST_IMAGE="${TEST_IMAGE:-https://eagle-image-test.s3.us-west-1.amazonaws.com/public/eagle-2.jpg}"
+
+if [ -z "$BASE_URL" ]; then
+  echo "usage: $0 <base-url> [api-endpoint]" >&2
+  exit 2
+fi
+
+BASE_URL="${BASE_URL%/}"
+IMAGE_URL="${BASE_URL}${API_ENDPOINT}"
+# CloudFront and API Gateway can serve a stale or still-propagating deployment
+# for a few seconds after the stack updates, so each check gets a few tries.
+RETRIES="${RETRIES:-5}"
+RETRY_DELAY="${RETRY_DELAY:-6}"
+
+failures=0
+
+# encoded_test_image URL-encodes the source image so it survives as a query
+# parameter value.
+encoded_test_image() {
+  jq -rn --arg u "$TEST_IMAGE" '$u|@uri'
+}
+
+# fetch performs a request and writes the body to $body_file, echoing
+# "<status> <content-type>" on stdout.
+fetch() {
+  local url="$1" accept="${2:-}"
+  local args=(--silent --show-error --location --max-time 30
+              --output "$body_file" --write-out '%{http_code} %{content_type}')
+  if [ -n "$accept" ]; then
+    args+=(--header "Accept: $accept")
+  fi
+  curl "${args[@]}" "$url"
+}
+
+# check runs one assertion, retrying while the response is not what we expect.
+# Arguments: name, url, accept header, expected status, expected content-type
+# substring (empty to skip the content-type assertion).
+check() {
+  local name="$1" url="$2" accept="$3" want_status="$4" want_type="${5:-}"
+  local attempt=1 status type result
+
+  while [ "$attempt" -le "$RETRIES" ]; do
+    result="$(fetch "$url" "$accept" || true)"
+    status="${result%% *}"
+    type="${result#* }"
+
+    if [ "$status" = "$want_status" ] &&
+       { [ -z "$want_type" ] || [[ "$type" == *"$want_type"* ]]; }; then
+      echo "PASS  $name (status $status${want_type:+, $type})"
+      return 0
+    fi
+
+    if [ "$attempt" -lt "$RETRIES" ]; then
+      echo "      $name: got status ${status:-none}${type:+ / $type}, retrying in ${RETRY_DELAY}s ($attempt/$RETRIES)"
+      sleep "$RETRY_DELAY"
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  echo "FAIL  $name"
+  echo "      url:      $url"
+  echo "      expected: status $want_status${want_type:+, content-type containing $want_type}"
+  echo "      actual:   status ${status:-none}${type:+, content-type $type}"
+  echo "      body:     $(head -c 300 "$body_file" 2>/dev/null || true)"
+  failures=$((failures + 1))
+  return 0
+}
+
+body_file="$(mktemp)"
+trap 'rm -f "$body_file"' EXIT
+
+encoded="$(encoded_test_image)"
+
+echo "Smoke testing $BASE_URL (endpoint $API_ENDPOINT)"
+echo
+
+check "health endpoint" \
+  "${BASE_URL}/health" "" "200"
+
+check "transforms an image" \
+  "${IMAGE_URL}?width=200&url=${encoded}" "" "200" "image/"
+
+check "resizes and crops" \
+  "${IMAGE_URL}?width=100&height=100&fit=cover&url=${encoded}" "" "200" "image/"
+
+check "negotiates webp from Accept" \
+  "${IMAGE_URL}?width=200&url=${encoded}" "image/webp,*/*" "200" "image/webp"
+
+check "rejects a request with no url" \
+  "${IMAGE_URL}" "" "400"
+
+check "404s an unknown path" \
+  "${BASE_URL}/not-a-real-path" "" "404"
+
+echo
+if [ "$failures" -gt 0 ]; then
+  echo "$failures check(s) failed."
+  exit 1
+fi
+
+echo "All checks passed."


### PR DESCRIPTION
Brings the project in line with the [awesome-go contribution requirements](https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md) so it can be submitted for listing.

## The blocker

`go.mod` declared the module as `github.com/zantez/image-api`, but the repository lives at `github.com/nicobistolfi/eagle-image-api`. Nothing could resolve the package: the pkg.go.dev and Go Report Card badges already in the README both pointed at a path that does not exist, and `go install github.com/nicobistolfi/eagle-image-api/cmd/eagle@latest` — the command the README tells people to run — could not work. Fixed, along with every import.

## Requirements and where they stand

| Requirement | Before | After |
| --- | --- | --- |
| `go.mod` resolves at the repo path | broken | fixed |
| Test coverage ≥ 80% | ~33% | **91.4%** |
| Go Report Card A- or better | gocyclo failures | gofmt, vet, golint, gocyclo, ineffassign, misspell all clean |
| Docs on exported identifiers | partial | every package and exported symbol |
| Coverage report published | none | Codecov, wired into CI |
| Documented contribution process | none | CONTRIBUTING.md, SECURITY.md, templates |
| CI on pull requests | called workflow only | runs standalone too |
| ≥ 5 months of history | Nov 2023 onward | unchanged |
| SemVer `vX.Y.Z` release | tag is `1.0.0` | **needs a tag — see below** |

## Coverage

Reaching 80% meant making the code testable rather than writing tests around it:

- **commands** 18.7% → 92.3%. Depends on `ecrAPI`/`cfnAPI` interfaces and an injectable docker runner instead of the concrete AWS SDK clients, so deployment logic runs against fakes without credentials. `buildParameters`, `buildTags`, `stackName`, and `decodeAuthToken` split out as pure functions.
- **handler** 0% → 100%. Internal helpers return a response instead of `(response, nil)`, which removed branches that could never carry an error.
- **config** 0% → 100%. Added `FromEnv` returning a value; `Load` still populates the global.
- **logger** 0% → 100%. Extracted `ParseLevel` and `InitWithWriter`.
- **image** 33% → 89.9%. Covers fetching, every fit mode, operations, and format negotiation against real libvips.

The old `commands` tests asserted things like `"eagle-image-api-" + "dev" == "eagle-image-api-dev"` — they exercised the test, not the code. Replaced.

## Two bugs the new tests found

**Arbitrary rotation crashed the process.** `rotate=45` (any angle that is not a multiple of 90) segfaulted. govips dereferences the background colour without a nil check and the call passed `nil`, so the request took down the Lambda rather than returning an error. Now passes a transparent background.

**A reachable CVE.** govulncheck reports [GO-2026-5061](https://pkg.go.dev/vuln/GO-2026-5061) as reachable: a panic decoding malformed WebP in `golang.org/x/image`, reached through govips. This service decodes images supplied by the caller, so it is a denial of service on any deployment. Upgraded to v0.43.0; govulncheck is now clean.

That upgrade requires Go 1.25, which moves the toolchain in `go.mod` and both Dockerfiles. **This is the one change here with a blast radius** — worth a look before merging.

## Complexity

Go Report Card runs gocyclo, which flagged four functions. Split along the seams they already had: `ParseQueryParams` into typed parameter readers, `resize` into `applyFit` plus `resizeFill`, `applyOperations` into a `rotate` helper, and `convertFormat` into `avifAllowed` plus one function per encoder. Highest complexity is now 13, down from 25.

## CI

`ci.yml` was `workflow_call` only, so the CI badge in the README had no status to show and pull requests from forks got no standalone check. It now also triggers on `push` to main and on `pull_request`, and stays callable so the deploy workflows still gate on a green build.

**Tradeoff worth flagging:** because the deploy workflows still call `ci.yml`, pull requests now run the build twice — once standalone, once via `deploy-pull.yml`. Removing the `ci` job from the deploy workflows would fix that but would drop the gate on production deploys, which did not seem like a good trade to make unilaterally. Happy to change it either way.

Also added `codecov.yml` (holds the 80% line) and bumped golangci-lint-action to v7, which the v2 config format requires. `CODECOV_TOKEN` is already set as a repository secret.

## Docs

CONTRIBUTING.md covers libvips setup, the exact checks CI runs, and how releases are cut. SECURITY.md covers private reporting and scope. Plus issue and PR templates.

The README documented a Serverless Framework deploy path (`sls deploy`) that no longer exists — the project moved to CloudFormation and the `eagle` CLI. Corrected, since awesome-go asks that a project work as documented.

## Still needed before submitting to awesome-go

**A SemVer tag.** The only tag is `1.0.0`; awesome-go requires the `v` prefix. Once this merges:

```bash
git tag -a v1.1.0 -m "v1.1.0"
git push origin v1.1.0
```

That also triggers GoReleaser and populates pkg.go.dev. After the tag lands, the three links the awesome-go PR asks for are:

- https://pkg.go.dev/github.com/nicobistolfi/eagle-image-api
- https://goreportcard.com/report/github.com/nicobistolfi/eagle-image-api
- https://app.codecov.io/gh/nicobistolfi/eagle-image-api

## Not addressed

Error responses return the raw govips error, which includes a full Go stack trace in the HTTP body. It is an information leak and it is ugly, but changing it alters the response contract for existing clients, so I left it alone. Worth a follow-up.

## Verification

`gofmt`, `go vet`, `staticcheck`, `golint`, `golangci-lint`, `gocyclo`, `actionlint`, and `govulncheck` are all clean; `go test -race ./...` passes across all seven packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)