### PR TITLE
Consolidate the open Dependabot updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.43.4
 	github.com/aws/aws-sdk-go-v2/config v1.32.35
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.9
-	github.com/aws/aws-sdk-go-v2/service/ecr v1.56.2
-	github.com/davidbyttow/govips/v2 v2.17.0
+	github.com/aws/aws-sdk-go-v2/service/ecr v1.60.4
+	github.com/davidbyttow/govips/v2 v2.18.0
 	github.com/spf13/cobra v1.10.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.36 h1:jbGY4CXLzZElOXgGsexlC3Hi+3Y
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.36/go.mod h1:uBu/9aKsS/UQGc72RAt3y54kjgYQxmhut8ZD2dXCDNE=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.9 h1:AISf54dn2oMUmhoWt4UH80xC8GqlZectZIcffiJzp6U=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.71.9/go.mod h1:YWA53lezhB2wltdgeVvDQEIwGVKWh/n+yU5Wh0YTxCw=
-github.com/aws/aws-sdk-go-v2/service/ecr v1.56.2 h1:B/psparkCzFM8Ct1MHyOLQ9I6GxpC8GaIgWLMgp1uv8=
-github.com/aws/aws-sdk-go-v2/service/ecr v1.56.2/go.mod h1:BcTorrilUv1q7JyC3X8qiVc48qJpttMTIb3bdVV92lA=
+github.com/aws/aws-sdk-go-v2/service/ecr v1.60.4 h1:qIgueZwgw+rANqXuL1Cjk2Lm/Pihbw2nx3C1D7eQD+k=
+github.com/aws/aws-sdk-go-v2/service/ecr v1.60.4/go.mod h1:Jr9Mh7l72YtNr8nmEwcJiU4xwCerZB8/krBWW4RckmY=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.15 h1:JJLBQxwY+AFwuPAi5ivGc1ChnTdUt4cXMv7e76m2c/Y=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.15/go.mod h1:lQknBIe78MVL0cQOQDlag8KGflMbMEVFx9mB6O8ENvk=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.35 h1:BBEElKh4a+rKshvjrfpajTe9CbpZvrbb4Jkg2PB7RzA=
@@ -35,8 +35,8 @@ github.com/aws/smithy-go v1.27.6/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqx
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davidbyttow/govips/v2 v2.17.0 h1:TFAjcaEqYpumRoIz2m1Ptr9Fhdg3H0R3FKixKS+4Jo8=
-github.com/davidbyttow/govips/v2 v2.17.0/go.mod h1:HF7B5oTeNolUjdBAYVIZQ8S5nhQd1CfDf0rMlYSMJv8=
+github.com/davidbyttow/govips/v2 v2.18.0 h1:pZRshWVYvewP/TZx3yZ7YeC42WyLXg53tHy5Qt8nT9E=
+github.com/davidbyttow/govips/v2 v2.18.0/go.mod h1:8+nst5zfMoats12PgmmAPh6p5OfjDaXK0BXMFl/vOcM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Rolls the outstanding Dependabot pull requests into one change, so the dependency bump gets reviewed, built, and deployed once instead of three times.

Supersedes #41, #44, and #45.

## What moved

| Dependency | From | To | Dependabot PR |
| --- | --- | --- | --- |
| `github.com/aws/aws-sdk-go-v2/service/ecr` | 1.56.2 | 1.60.4 | #44 |
| `github.com/davidbyttow/govips/v2` | 2.17.0 | 2.18.0 | #41 |

**#45 is already satisfied.** It proposed `aws-sdk-go-v2` 1.41.5 → 1.43.4, but main is already on 1.43.4 — it arrived as a transitive bump when #43 merged. There is no change for it to make, so nothing here carries its name. Dependabot should close it on its own once it next re-evaluates.

The diff is 6 insertions and 6 deletions across `go.mod` and `go.sum`; `go mod tidy` moved no other pins.

## The one worth watching

**govips 2.18.0** is the only bump with real risk here. It wraps libvips through cgo, so a regression would show up at runtime rather than at compile time, and it sits directly under every image transformation this service performs.

I ran the full suite against real libvips rather than trusting a clean build:

- All 7 packages pass under `-race`
- Coverage holds at **91.4%**
- The arbitrary-angle rotation path is covered and passes — that is the one that segfaulted before, where govips dereferenced a nil background colour

The ECR bump only affects the `eagle deploy` CLI path, which is covered by the fake-client tests.

## Verification

`gofmt`, `go vet`, `staticcheck`, and `golangci-lint` are all clean.

`govulncheck` now reports **zero vulnerabilities**, including in imported packages — down from seven before the AWS SDK updates. Two remain in required-but-uncalled modules.

## Note

I did not close #41, #44, or #45 by hand. Dependabot closes its own pull requests once the target versions land on main, and letting it do that keeps its state consistent. Say the word if you would rather I close them now.