### PR TITLE
Widen the allowed Stage values so deployers can choose their own stage name

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,19 @@ eagle deploy --stage dev
 
 # Deploy to production
 eagle deploy --stage prod
+
+# Deploy an ad-hoc stage of your own
+eagle deploy --stage my-test
+```
+
+`dev` and `prod` are the conventional stages, but `--stage` accepts any name of
+1-20 characters made of lowercase letters, digits and hyphens, starting with a
+letter. The stage namespaces every resource in the stack, so each one is a fully
+independent deployment. An ad-hoc stage creates its own CloudFront distribution,
+Lambda function and API Gateway, so delete it when you are finished:
+
+```bash
+aws cloudformation delete-stack --stack-name eagle-image-api-my-test
 ```
 
 To deploy the template directly instead of using the CLI:

--- a/internal/commands/deploy.go
+++ b/internal/commands/deploy.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 
@@ -34,7 +35,17 @@ const (
 
 	// stackPollInterval is how long to wait between stack status checks.
 	stackPollInterval = 10 * time.Second
+
+	// stagePattern constrains --stage to names that are simultaneously valid
+	// as a CloudFormation stack name suffix, an IAM role name segment, an API
+	// Gateway stage name and a CloudFront origin path. It must stay identical
+	// to the AllowedPattern of the Stage parameter in template.yml; a test
+	// guards against the two drifting apart.
+	stagePattern = `^[a-z][a-z0-9-]{0,19}$`
 )
+
+// stageRegexp is the compiled form of stagePattern.
+var stageRegexp = regexp.MustCompile(stagePattern)
 
 // templateURL and templateClient are variables rather than constants so tests
 // can point the fetch at a local server.
@@ -120,7 +131,7 @@ func init() {
 // init so tests can build an independent command with its own flag storage.
 func registerDeployFlags(cmd *cobra.Command, dst *deployFlags) {
 	f := cmd.Flags()
-	f.StringVar(&dst.stage, "stage", "dev", "Deployment stage (sets Stage parameter and stack name)")
+	f.StringVar(&dst.stage, "stage", "dev", "Deployment stage, 1-20 characters of lowercase letters, digits and hyphens starting with a letter (e.g. dev, prod, my-test); sets the Stage parameter and stack name")
 	f.StringVar(&dst.region, "region", "us-west-1", "AWS region")
 	f.StringVar(&dst.template, "template", "", "Path to local CloudFormation template (default: fetched from GitHub)")
 	f.StringVar(&dst.quality, "quality", "80", "Image quality (0-100)")
@@ -162,6 +173,12 @@ func runDeploy(cmd *cobra.Command, _ []string) error {
 // run performs the full deployment: fetch template, mirror the image into
 // ECR, then create or update the CloudFormation stack.
 func (d *deployer) run(ctx context.Context) error {
+	// Validate first: an unusable stage name would otherwise only surface as a
+	// CloudFormation error, after a full image pull and ECR push.
+	if err := validateStage(d.flags.stage); err != nil {
+		return err
+	}
+
 	templateBody, err := getTemplateBody(d.flags.template)
 	if err != nil {
 		return fmt.Errorf("getting template: %w", err)
@@ -182,6 +199,15 @@ func (d *deployer) run(ctx context.Context) error {
 	}
 
 	return d.printStackOutputs(ctx, name)
+}
+
+// validateStage checks that stage can be used as a deployment namespace across
+// every AWS resource the template names after it.
+func validateStage(stage string) error {
+	if stageRegexp.MatchString(stage) {
+		return nil
+	}
+	return fmt.Errorf("invalid stage %q: must be 1-20 characters of lowercase letters, digits and hyphens, starting with a letter (pattern %s), for example dev, prod or my-test", stage, stagePattern)
 }
 
 // stackName derives the CloudFormation stack name for a deployment stage.

--- a/internal/commands/deploy_test.go
+++ b/internal/commands/deploy_test.go
@@ -613,6 +613,83 @@ func TestStackName(t *testing.T) {
 	}
 }
 
+// --- stage validation ------------------------------------------------------
+
+func TestValidateStage(t *testing.T) {
+	tests := []struct {
+		name  string
+		stage string
+		valid bool
+	}{
+		{"conventional dev", "dev", true},
+		{"conventional prod", "prod", true},
+		{"ad-hoc name", "nicotest", true},
+		{"hyphens and digits", "my-test-1", true},
+		{"single letter", "a", true},
+		{"twenty characters", strings.Repeat("a", 20), true},
+		{"empty", "", false},
+		{"uppercase", "Prod", false},
+		{"leading digit", "1abc", false},
+		{"underscore", "has_underscore", false},
+		{"space", "has space", false},
+		{"leading hyphen", "-leading-hyphen", false},
+		{"twenty one characters", strings.Repeat("a", 21), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateStage(tt.stage)
+			if tt.valid {
+				if err != nil {
+					t.Fatalf("validateStage(%q) error: %v", tt.stage, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateStage(%q) = nil, want an error", tt.stage)
+			}
+			if !strings.Contains(err.Error(), stagePattern) {
+				t.Errorf("error = %v, want it to state the allowed pattern", err)
+			}
+			if !strings.Contains(err.Error(), "dev") {
+				t.Errorf("error = %v, want it to give an example", err)
+			}
+		})
+	}
+}
+
+// TestStageFlagUsageDocumentsFormat keeps `eagle deploy --help` explicit about
+// which stage names are accepted.
+func TestStageFlagUsageDocumentsFormat(t *testing.T) {
+	f := DeployCmd.Flags().Lookup("stage")
+	if f == nil {
+		t.Fatal("stage flag not found")
+	}
+	for _, want := range []string{"1-20", "lowercase", "my-test"} {
+		if !strings.Contains(f.Usage, want) {
+			t.Errorf("stage flag usage %q does not mention %q", f.Usage, want)
+		}
+	}
+}
+
+// TestStagePatternMatchesTemplate guards against the client-side pattern and
+// the template's AllowedPattern drifting apart.
+func TestStagePatternMatchesTemplate(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "template.yml"))
+	if err != nil {
+		t.Skipf("template.yml not readable: %v", err)
+	}
+	template := string(data)
+
+	want := "    AllowedPattern: '" + stagePattern + "'\n"
+	if !strings.Contains(template, want) {
+		t.Errorf("template.yml does not declare AllowedPattern %s for Stage", stagePattern)
+	}
+	if strings.Contains(template, "AllowedValues: [dev, prod]") {
+		t.Error("template.yml still restricts Stage to AllowedValues")
+	}
+}
+
 // --- stack lifecycle -------------------------------------------------------
 
 func TestDeployStackCreatesWhenMissing(t *testing.T) {
@@ -908,6 +985,25 @@ func TestDeployerRunTemplateFailure(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "getting template") {
 		t.Errorf("error = %v, want it to identify the template step", err)
+	}
+}
+
+// TestDeployerRunRejectsInvalidStageBeforeDocker pins the ordering the fix is
+// about: an unusable stage costs no image pull or ECR push.
+func TestDeployerRunRejectsInvalidStageBeforeDocker(t *testing.T) {
+	docker := &recordingDocker{}
+	d, _ := newTestDeployer(&fakeECR{}, &fakeCFN{}, docker.run)
+	d.flags.stage = "Not Valid!"
+
+	err := d.run(context.Background())
+	if err == nil {
+		t.Fatal("expected an error for an invalid stage")
+	}
+	if !strings.Contains(err.Error(), stagePattern) {
+		t.Errorf("error = %v, want it to state the allowed pattern", err)
+	}
+	if len(docker.calls) != 0 {
+		t.Errorf("docker was invoked %d times, want 0 before stage validation passes", len(docker.calls))
 	}
 }
 

--- a/template.yml
+++ b/template.yml
@@ -5,7 +5,9 @@ Parameters:
   Stage:
     Type: String
     Default: dev
-    AllowedValues: [dev, prod]
+    AllowedPattern: '^[a-z][a-z0-9-]{0,19}$'
+    ConstraintDescription: must be 1-20 characters, lowercase letters, digits and hyphens, starting with a letter (e.g. dev, prod, my-test)
+    Description: Deployment stage namespace. dev and prod are the conventional values; any name matching the pattern is allowed.
   ImageUri:
     Type: String
     Description: ECR image URI for the Lambda function


### PR DESCRIPTION
## Summary

`template.yml` restricted the `Stage` parameter to `AllowedValues: [dev, prod]`, but `eagle deploy --stage` accepted any string and was documented as free-form. A stage outside that list failed in CloudFormation only after a full Docker pull and ECR push.

- `template.yml`: `Stage` now uses `AllowedPattern: '^[a-z][a-z0-9-]{0,19}$'` with a `ConstraintDescription`, instead of a fixed `AllowedValues` list. `Default: dev` is unchanged.
- `internal/commands/deploy.go`: added `validateStage`, called at the very top of `deployer.run` — before the template fetch, the Docker pull, and the ECR push — so a malformed stage fails fast with a message that states the rule. The `--stage` flag help text now documents the accepted format.
- `internal/commands/deploy_test.go`: table-driven `validateStage` coverage, an ordering test asserting no Docker calls happen for an invalid stage, and a consistency test that the CLI pattern matches the template's `AllowedPattern`.
- `README.md`: documents an ad-hoc stage example and the `delete-stack` cleanup step.

Both CI deploy workflows (`Stage=dev`, `Stage=prod`) are untouched and keep working as before.

Closes #52

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `staticcheck ./...` (clean)
- [x] `govulncheck ./...` (no vulnerabilities in called code)